### PR TITLE
feat(analytics): support passing options to usePageviewAnalytics

### DIFF
--- a/.changeset/grumpy-emus-joke.md
+++ b/.changeset/grumpy-emus-joke.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-analytics': minor
+---
+
+Add support for passing options to the analytics hook

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -2,9 +2,18 @@
 
 Utilities for collecting analytics from our applications.
 
-### `usePageviewAnalytics`
+### `usePageviewAnalytics({ siteId?: string, includedDomains?: string })`
 
 Sets up pageviews to be tracked by listening to router events, currently done with [Fathom](https://usefathom.com). Needs two environment variables to be set:
 
 - `NEXT_PUBLIC_FATHOM_SITE_ID` - The site ID for the application in Fathom
 - `NEXT_PUBLIC_FATHOM_INCLUDED_DOMAINS` - A space-separated list of domains that are eligible for tracking.
+
+Alternatively, you can pass in an options object with `siteId` and `includedDomains`:
+
+```js
+usePageviewAnalytics({
+  siteId: '1234',
+  includedDomains: 'example.com example2.com',
+})
+```


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->
Support passing options to `usePageviewAnalytics` so that we can support multiple "sites" served from a single app.

```ts
import usePageviewAnalytics from '@hashicorp/platform-analytics'

usePageviewAnalytics({
  siteId: process.env.NEXT_PUBLIC_FATHOM_SITE_ID_WAYPOINT,
  includedDomains: productData.analyticsConfig.includedDomains
})
```

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
