### PR TITLE
feat: update Webpack rule removal logic to support Next.js v12

### DIFF
--- a/.changeset/slimy-months-obey.md
+++ b/.changeset/slimy-months-obey.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/next-optimized-images': minor
+---
+
+Update Webpack rule removal logic to support Next.js v12

--- a/packages/next-optimized-images/lib/index.js
+++ b/packages/next-optimized-images/lib/index.js
@@ -17,11 +17,8 @@ const regexLikeCss = /\.(css|scss|sass)(\.webpack\[javascript\/auto\])?$/
  * @returns {object}
  */
 const withOptimizedImages = (nextConfig = {}, nextComposePlugins = {}) => {
-  const {
-    optimizeImages,
-    optimizeImagesInDev,
-    overwriteImageLoaderPaths,
-  } = getConfig(nextConfig)
+  const { optimizeImages, optimizeImagesInDev, overwriteImageLoaderPaths } =
+    getConfig(nextConfig)
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -66,14 +63,16 @@ const withOptimizedImages = (nextConfig = {}, nextComposePlugins = {}) => {
                 !subRule.test &&
                 !subRule.include &&
                 subRule.exclude &&
-                subRule.use &&
-                subRule.use.options &&
-                subRule.use.options.name
+                ((subRule.use &&
+                  subRule.use.options &&
+                  subRule.use.options.name) ||
+                  subRule.type === 'asset/resource')
               ) {
                 if (
-                  (String(subRule.issuer.test) === String(regexLikeCss) ||
+                  ((String(subRule.issuer.test) === String(regexLikeCss) ||
                     String(subRule.issuer) === String(regexLikeCss)) &&
-                  subRule.use.options.name.startsWith('static/media/')
+                    subRule.use.options.name.startsWith('static/media/')) ||
+                  subRule.type === 'asset/resource'
                 ) {
                   subRule.exclude.push(/\.(jpg|jpeg|png|svg|webp|gif|ico)$/)
                 }


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

This PR updates our patched version of `next-optimized-images` to support Next.js v12, which slightly tweaked the Webpack loader config used to load images. You can see the [v11 version here](https://github.com/vercel/next.js/blob/v11.1.4/packages/next/build/webpack/config/blocks/css/index.ts#L288-L313), and compare against the [v12 version here](https://github.com/vercel/next.js/blob/v12.0.9/packages/next/build/webpack/config/blocks/css/index.ts#L393-L412).

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
