### PR TITLE
enhance(analytics): sendBeacon check before script load

### DIFF
--- a/.changeset/wet-parents-guess.md
+++ b/.changeset/wet-parents-guess.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-analytics': patch
+---
+
+Adds a check for `navigator.sendBeacon` before the Fathom server-side script loads.

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -23,6 +23,9 @@ export default function usePageviewAnalytics({
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
+      // This short-circuit prwevents the following from happening:
+      // - Runtime crash if siteId or includedDomains are not set
+      // - Instant 404 when a Fathom client method is called and the navigator.sendBeacon method is unavailable
       if (!siteId || !includedDomains || !navigator.sendBeacon) return
 
       load(siteId, {

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -23,7 +23,7 @@ export default function usePageviewAnalytics({
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
-      if (!siteId || !includedDomains) return
+      if (!siteId || !includedDomains || !navigator.sendBeacon) return
 
       load(siteId, {
         url: 'https://tarantula.hashicorp.com/script.js',
@@ -44,6 +44,12 @@ export default function usePageviewAnalytics({
             !siteId ? '\nNEXT_PUBLIC_FATHOM_SITE_ID' : ''
           }${!includedDomains ? '\nNEXT_PUBLIC_FATHOM_INCLUDED_DOMAINS' : ''}
         `
+        )
+      }
+
+      if (!navigator.sendBeacon) {
+        console.warn(
+          "[@hashicorp/platform-analytics] Your browser's navigator.sendBeacon method was not found. Please enable it to test Fathom in dev."
         )
       }
     }

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -28,7 +28,7 @@ export default function usePageviewAnalytics({
       if (!siteId || !includedDomains) return
 
       // - Instant 404 when a Fathom client method is called and the navigator.sendBeacon method is unavailable
-      if (!navigator.sendBeacon) return
+      if (navigator.sendBeacon === undefined) return
 
       load(siteId, {
         url: 'https://tarantula.hashicorp.com/script.js',

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -23,10 +23,12 @@ export default function usePageviewAnalytics({
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
-      // This short-circuit prwevents the following from happening:
+      // These short-circuits prwevent the following from happening:
       // - Runtime crash if siteId or includedDomains are not set
+      if (!siteId || !includedDomains) return
+
       // - Instant 404 when a Fathom client method is called and the navigator.sendBeacon method is unavailable
-      if (!siteId || !includedDomains || !window.navigator.sendBeacon) return
+      if (!navigator.sendBeacon) return
 
       load(siteId, {
         url: 'https://tarantula.hashicorp.com/script.js',

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -16,14 +16,13 @@ function onRouteChangeComplete() {
  * Currently uses [fathom](https://usefathom.com) under the hood.
  */
 export default function usePageviewAnalytics({
-  // siteId = process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
-  siteId = 'e',
-  includedDomains = 'learn-git-nq-upgrade-analytics-hashicorp.vercel.app',
+  siteId = process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
+  includedDomains = process.env.NEXT_PUBLIC_FATHOM_INCLUDED_DOMAINS,
 }: UsePageViewAnalyticsOptions = {}): void {
   const router = useRouter()
 
   useEffect(() => {
-    if (typeof siteId === 'string') {
+    if (process.env.NODE_ENV === 'production') {
       // These short-circuits prwevent the following from happening:
       // - Prevents runtime crash if siteId or includedDomains are not set
       if (!siteId || !includedDomains) return

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -22,7 +22,7 @@ export default function usePageviewAnalytics({
   const router = useRouter()
 
   useEffect(() => {
-    if (process.env.NODE_ENV === 'production') {
+    if (typeof siteId === 'string') {
       // These short-circuits prwevent the following from happening:
       // - Prevents runtime crash if siteId or includedDomains are not set
       if (!siteId || !includedDomains) return

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -16,8 +16,9 @@ function onRouteChangeComplete() {
  * Currently uses [fathom](https://usefathom.com) under the hood.
  */
 export default function usePageviewAnalytics({
-  siteId = process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
-  includedDomains = process.env.NEXT_PUBLIC_FATHOM_INCLUDED_DOMAINS,
+  // siteId = process.env.NEXT_PUBLIC_FATHOM_SITE_ID,
+  siteId = 'e',
+  includedDomains = 'learn-git-nq-upgrade-analytics-hashicorp.vercel.app',
 }: UsePageViewAnalyticsOptions = {}): void {
   const router = useRouter()
 

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -24,10 +24,10 @@ export default function usePageviewAnalytics({
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
       // These short-circuits prwevent the following from happening:
-      // - Runtime crash if siteId or includedDomains are not set
+      // - Prevents runtime crash if siteId or includedDomains are not set
       if (!siteId || !includedDomains) return
 
-      // - Instant 404 when a Fathom client method is called and the navigator.sendBeacon method is unavailable
+      // - Prevents instant 404 when a Fathom client method is called and the navigator.sendBeacon method is unavailable
       if (navigator.sendBeacon === undefined) return
 
       load(siteId, {

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -26,7 +26,7 @@ export default function usePageviewAnalytics({
       // This short-circuit prwevents the following from happening:
       // - Runtime crash if siteId or includedDomains are not set
       // - Instant 404 when a Fathom client method is called and the navigator.sendBeacon method is unavailable
-      if (!siteId || !includedDomains || !navigator.sendBeacon) return
+      if (!siteId || !includedDomains || !window.navigator.sendBeacon) return
 
       load(siteId, {
         url: 'https://tarantula.hashicorp.com/script.js',


### PR DESCRIPTION
## Description

This PR introduces a check for `navigator.sendBeacon` before the Fathom server-side script loads. If `navigator.sendBeacon` exists, the script continues as normal. If not, the script short-circuits.

This check ensures that `navigator.sendBeacon`, a method used by the server-side Fathom script, is present before the script attempts to execute it.  If the script attempts execution and fails, the page the user is visiting will 404.

## PR Checklist 🚀

- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
