### PR TITLE
feat: rely on eslint-config-next's parser

### DIFF
--- a/.changeset/new-comics-fly.md
+++ b/.changeset/new-comics-fly.md
@@ -2,4 +2,6 @@
 '@hashicorp/platform-cli': minor
 ---
 
-Rely on eslint-config-next's parser instead of the deprecated babel-eslint parser
+* Rely on eslint-config-next's parser instead of the deprecated babel-eslint parser.
+* Only attempt to fix rules when not in CI, to ensure anything which is not caught locally will fail in CI.
+* Ensures fixes made by ESLint are applied.

--- a/.changeset/new-comics-fly.md
+++ b/.changeset/new-comics-fly.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-cli': minor
+---
+
+Rely on eslint-config-next's parser instead of the deprecated babel-eslint parser

--- a/package-lock.json
+++ b/package-lock.json
@@ -4301,31 +4301,6 @@
       "version": "2.2.0",
       "license": "Apache-2.0"
     },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.3.1.tgz",
@@ -24447,7 +24422,6 @@
         "@hashicorp/platform-cms": "0.3.0",
         "@typescript-eslint/eslint-plugin": "5.10.2",
         "@typescript-eslint/parser": "5.10.2",
-        "babel-eslint": "10.1.0",
         "chalk": "4.1.0",
         "commander": "7.2.0",
         "ejs": "3.1.5",
@@ -27203,7 +27177,7 @@
     },
     "packages/tools": {
       "name": "@hashicorp/platform-tools",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "ts-node": "^10.7.0"
@@ -28389,7 +28363,6 @@
         "@hashicorp/platform-cms": "0.3.0",
         "@typescript-eslint/eslint-plugin": "5.10.2",
         "@typescript-eslint/parser": "5.10.2",
-        "babel-eslint": "10.1.0",
         "chalk": "4.1.0",
         "commander": "7.2.0",
         "ejs": "3.1.5",
@@ -32409,22 +32382,6 @@
     },
     "axobject-query": {
       "version": "2.2.0"
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0"
-        }
-      }
     },
     "babel-jest": {
       "version": "27.3.1",

--- a/packages/cli/config/.eslintrc.js
+++ b/packages/cli/config/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
-  parser: 'babel-eslint',
+  // The parser is inherited from the eslint-config-next, extended here
+  extends: ['eslint:recommended', 'plugin:prettier/recommended', 'next'],
 
   plugins: ['jsx-a11y', 'prettier'],
 
@@ -121,8 +122,6 @@ module.exports = {
       },
     },
   ],
-
-  extends: ['eslint:recommended', 'plugin:prettier/recommended', 'next'],
 
   rules: {
     // An odd rule that leads to odd code patterns, we are opting to disable it for our projects (https://app.asana.com/0/1100423001970639/1199667739287945/f)

--- a/packages/cli/next-hashicorp
+++ b/packages/cli/next-hashicorp
@@ -142,13 +142,16 @@ async function doEslint(files) {
 
   const eslint = new ESLint({
     extensions: validExtensions,
-    fix: true,
+    // Do not attempt to fix in CI, as we can't persist the changes
+    fix: process.env.CI ? false : true,
     // ref: https://eslint.org/docs/user-guide/command-line-interface#--resolve-plugins-relative-to
     resolvePluginsRelativeTo: __dirname,
   })
   const results = await eslint.lintFiles(validFiles)
   const errors = []
   const warnings = []
+
+  await ESLint.outputFixes(results)
 
   for (const { filePath: file, messages } of results) {
     const fileErrors = []

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,6 @@
     "@hashicorp/platform-cms": "0.3.0",
     "@typescript-eslint/eslint-plugin": "5.10.2",
     "@typescript-eslint/parser": "5.10.2",
-    "babel-eslint": "10.1.0",
     "chalk": "4.1.0",
     "commander": "7.2.0",
     "ejs": "3.1.5",


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->
- `babel-eslint` is deprecated, and `eslint-config-next`, which we are extending, provides a parser for us.
- Ensure fixes made by ESLint are output to their respective files

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
