### PR TITLE
feat(tools): adds --resolve-paths option, defaults to true

### DIFF
--- a/.changeset/khaki-pans-repair.md
+++ b/.changeset/khaki-pans-repair.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-tools': minor
+---
+
+Add new `--resolve-paths` flag, which allows us to opt-out of resolving based on the baseUrl and custom paths in tsconfig.json

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -38,6 +38,11 @@ $ hc-tools ./scripts/my-script.ts
 
 As part of this, `hc-tools` will also load environment variables defined in `.env` using the same [loading strategy as Next.js](https://www.npmjs.com/package/@next/env).
 
+### Options
+
+- `--project [path to tsconfig]` - If specified, loads the tsconfig from the specified path
+- `--resolve-paths [true|false]` - Controls whether or not to resolve paths based on local tsconfig settings (default: `true`)
+
 ## Included scripts
 
 ### `add-deploy-preview-script`

--- a/packages/tools/src/__tests__/index.test.ts
+++ b/packages/tools/src/__tests__/index.test.ts
@@ -37,6 +37,16 @@ describe('hc-tools', () => {
     expect(result).toContain(`hello from lib`)
   })
 
+  test('does not load baseUrl or paths with --resolve-paths=false', () => {
+    setCwdToFixture('tsconfig-paths-env')
+
+    try {
+      execHCTools('./scripts/my-script.ts', '--resolve-paths', 'false')
+    } catch (err) {
+      expect(err.message).toContain("Cannot find module 'lib/index'")
+    }
+  })
+
   test('respects custom paths with different tsconfig', () => {
     setCwdToFixture('tsconfig-paths-env')
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -103,7 +103,6 @@ async function main() {
   await script(...rest)
 }
 
-main().catch((err) => {
-  console.error(err)
+main().catch(() => {
   process.exit(1)
 })

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -11,15 +11,23 @@ import { doesFileExist } from './util'
 register({
   transpileOnly: true,
   skipIgnore: true,
+  skipProject: true,
   compilerOptions: { module: 'CommonJS' },
 })
 
 async function main() {
-  const argv = yargs.option('project', {
-    alias: 'p',
-    description: 'If specified, loads the tsconfig from the specified path',
-    type: 'string',
-  }).argv
+  const argv = yargs
+    .option('project', {
+      alias: 'p',
+      description: 'If specified, loads the tsconfig from the specified path',
+      type: 'string',
+    })
+    .option('resolve-paths', {
+      description:
+        'Controls whether or not to resolve paths based on local tsconfig settings',
+      default: true,
+      type: 'boolean',
+    }).argv
 
   const [scriptName, ...rest] = argv._
 
@@ -46,7 +54,13 @@ async function main() {
       ? ['--project', argv.project]
       : ['--skipProject']
 
-    execFileSync(
+    // including the require option here to support paths and baseUrl,
+    // per: https://www.npmjs.com/package/ts-node#paths-and-baseurl
+    const requireOptions = argv['resolve-paths']
+      ? ['--require', 'tsconfig-paths/register']
+      : []
+
+    return execFileSync(
       'npx',
       [
         'ts-node',
@@ -54,16 +68,12 @@ async function main() {
         '--skipIgnore',
         '--compilerOptions',
         '{"module": "CommonJS"}',
-        // including the require option here to support paths and baseUrl,
-        // per: https://www.npmjs.com/package/ts-node#paths-and-baseurl
-        '--require',
-        'tsconfig-paths/register',
+        ...requireOptions,
         ...projectOptions,
         scriptName as string,
       ],
       { stdio: 'inherit', env: { ...process.env, ...env.combinedEnv } }
     )
-    return
   }
 
   const scriptPath = path.join(__dirname, '..', 'scripts', scriptName as string)
@@ -93,4 +103,7 @@ async function main() {
   await script(...rest)
 }
 
-main()
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->
Adds `--resolve-paths` option, defaulting to true, which allows us to opt out of leveraging `tsconfig-paths/register` to resolve based on `baseUrl` and `paths` from `tsconfig.json`.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
