### PR TITLE
feat(platform-packer-plugins): abstract our packer plugins util

### DIFF
--- a/.changeset/seven-shoes-boil.md
+++ b/.changeset/seven-shoes-boil.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-packer-plugins': minor
+---
+
+Initial release of resolvePluginDocs, which is an abstraction of existing functionality to take in a packer plugin manifest and decorate it with docs file data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1499,6 +1499,10 @@
       "resolved": "packages/nextjs-plugin",
       "link": true
     },
+    "node_modules/@hashicorp/platform-packer-plugins": {
+      "resolved": "packages/packer-plugins",
+      "link": true
+    },
     "node_modules/@hashicorp/platform-postcss-config": {
       "resolved": "packages/postcss-config",
       "link": true
@@ -3135,6 +3139,15 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+      "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/autoprefixer": {
       "version": "9.7.2",
       "dev": true,
@@ -3835,6 +3848,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -9301,6 +9322,20 @@
         "graphql": "14.x || 15.x"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -11155,6 +11190,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -19805,6 +19849,37 @@
         "node": ">= 4"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/section-matter/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/section-matter/node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
       "license": "MIT",
@@ -20927,6 +21002,14 @@
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-dirs": {
@@ -22842,6 +22925,11 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/unherit": {
       "version": "1.1.3",
@@ -26080,7 +26168,8 @@
       }
     },
     "packages/configs": {
-      "version": "0.0.0",
+      "name": "@hashicorp/platform-configs",
+      "version": "0.1.0",
       "license": "MPL-2.0"
     },
     "packages/docs-mdx": {
@@ -26410,6 +26499,19 @@
       "peerDependencies": {
         "browserslist": ">= 4",
         "postcss": ">= 8"
+      }
+    },
+    "packages/packer-plugins": {
+      "name": "@hashicorp/platform-packer-plugins",
+      "version": "0.0.0",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.9",
+        "gray-matter": "^4.0.3",
+        "isomorphic-unfetch": "^3.1.0"
+      },
+      "devDependencies": {
+        "@types/adm-zip": "^0.5.0"
       }
     },
     "packages/postcss-config": {
@@ -27198,7 +27300,7 @@
     },
     "packages/tools": {
       "name": "@hashicorp/platform-tools",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@next/env": "^12.1.4",
@@ -29848,6 +29950,15 @@
         }
       }
     },
+    "@hashicorp/platform-packer-plugins": {
+      "version": "file:packages/packer-plugins",
+      "requires": {
+        "@types/adm-zip": "^0.5.0",
+        "adm-zip": "^0.5.9",
+        "gray-matter": "*",
+        "isomorphic-unfetch": "^3.1.0"
+      }
+    },
     "@hashicorp/platform-postcss-config": {
       "version": "file:packages/postcss-config",
       "requires": {
@@ -30380,7 +30491,7 @@
         "@next/env": "^12.1.4",
         "ts-node": "^10.7.0",
         "tsconfig-paths": "^3.14.1",
-        "yargs": "*"
+        "yargs": "^17.4.1"
       },
       "dependencies": {
         "@next/env": {
@@ -31694,6 +31805,15 @@
         "@types/estree": "*"
       }
     },
+    "@types/adm-zip": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+      "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/autoprefixer": {
       "version": "9.7.2",
       "dev": true,
@@ -32245,6 +32365,11 @@
     },
     "acorn-walk": {
       "version": "7.2.0"
+    },
+    "adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -35980,6 +36105,17 @@
         "form-data": "^3.0.0"
       }
     },
+    "gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      }
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -37140,6 +37276,15 @@
     },
     "isobject": {
       "version": "3.0.1"
+    },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -43137,6 +43282,30 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        }
+      }
+    },
     "seek-bzip": {
       "version": "1.0.6",
       "requires": {
@@ -43916,6 +44085,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "strip-dirs": {
       "version": "2.1.0",
@@ -45207,6 +45381,11 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/packages/packer-plugins/README.md
+++ b/packages/packer-plugins/README.md
@@ -1,0 +1,3 @@
+# `@hashicorp/platform-packer-plugins`
+
+Utilities used for fetching data for packer plugins from a plugin manifest file.

--- a/packages/packer-plugins/__tests__/index.test.ts
+++ b/packages/packer-plugins/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { resolvePluginDocs } from '..'
 
 describe('resolvePluginDocs', () => {
   // un-skip this to validate that the full flow works
+  // TODO: add a fixture and use nock
   test.skip('resolve docs files for each entry in the manifest', async () => {
     expect(
       await resolvePluginDocs([

--- a/packages/packer-plugins/__tests__/index.test.ts
+++ b/packages/packer-plugins/__tests__/index.test.ts
@@ -1,0 +1,111 @@
+import { resolvePluginDocs } from '..'
+
+describe('resolvePluginDocs', () => {
+  test('resolve docs files for each entry in the manifest', async () => {
+    expect(
+      await resolvePluginDocs([
+        {
+          title: '1&1',
+          path: 'oneandone',
+          repo: 'hashicorp/packer-plugin-oneandone',
+          pluginTier: 'community',
+          version: 'latest',
+        },
+      ])
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "files": Array [
+            Object {
+              "filePath": "docs/builders/oneandone.mdx",
+              "fileString": "---
+      description: The 1&1 builder is able to create images for 1&1 cloud.
+      page_title: 1&1 - Builder
+      nav_title: 1&1
+      ---
+
+      # 1&1 Builder
+
+      Type: \`oneandone\`
+      Artifact BuilderId: \`packer.oneandone\`
+
+      The 1&1 Builder is able to create virtual machines for
+      [1&1](https://www.1and1.com/).
+
+      ## Configuration Reference
+
+      There are many configuration options available for the builder. They are
+      segmented below into two categories: required and optional parameters. Within
+      each category, the available configuration keys are alphabetized.
+
+      In addition to the options listed here, a
+      [communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+      builder. In addition to the options defined there, a private key file
+      can also be supplied to override the typical auto-generated key:
+
+      - \`ssh_private_key_file\` (string) - Path to a PEM encoded private key file to use to authenticate with SSH.
+        The \`~\` can be used in path and will be expanded to the home directory
+        of current user.
+
+
+      ### Required
+
+      - \`source_image_name\` (string) - 1&1 Server Appliance name of type \`IMAGE\`.
+
+      - \`token\` (string) - 1&1 REST API Token. This can be specified via
+        environment variable \`ONEANDONE_TOKEN\`
+
+      ### Optional
+
+      - \`data_center_name\` - Name of virtual data center. Possible values \\"ES\\",
+        \\"US\\", \\"GB\\", \\"DE\\". Default value \\"US\\"
+
+      - \`disk_size\` (string) - Amount of disk space for this image in GB. Defaults
+        to \\"50\\"
+
+      - \`image_name\` (string) - Resulting image. If \\"image_name\\" is not provided
+        Packer will generate it
+
+      - \`retries\` (number) - Number of retries Packer will make status requests
+        while waiting for the build to complete. Default value \\"600\\".
+
+      <!-- markdown-link-check-disable -->
+
+      - \`url\` (string) - Endpoint for the 1&1 REST API. Default URL
+      \\"<https://cloudpanel-api.1and1.com/v1>\\"
+      <!-- markdown-link-check-enable -->
+
+      ## Example
+
+      Here is a basic example:
+
+      \`\`\`json
+      {
+        \\"builders\\": [
+          {
+            \\"type\\": \\"oneandone\\",
+            \\"disk_size\\": \\"50\\",
+            \\"image_name\\": \\"test5\\",
+            \\"source_image_name\\": \\"ubuntu1604-64min\\",
+            \\"ssh_username\\": \\"root\\",
+            \\"ssh_private_key_file\\": \\"/path/to/private/ssh/key\\"
+          }
+        ]
+      }
+      \`\`\`
+      ",
+              "path": "oneandone",
+              "sourceUrl": "https://github.com/hashicorp/packer-plugin-oneandone/blob/main/docs/builders/oneandone.mdx",
+              "title": "1&1",
+            },
+          ],
+          "path": "oneandone",
+          "pluginTier": "community",
+          "repo": "hashicorp/packer-plugin-oneandone",
+          "title": "1&1",
+          "version": "latest",
+        },
+      ]
+    `)
+  })
+})

--- a/packages/packer-plugins/__tests__/index.test.ts
+++ b/packages/packer-plugins/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import { resolvePluginDocs } from '..'
 
 describe('resolvePluginDocs', () => {
-  test('resolve docs files for each entry in the manifest', async () => {
+  // un-skip this to validate that the full flow works
+  test.skip('resolve docs files for each entry in the manifest', async () => {
     expect(
       await resolvePluginDocs([
         {

--- a/packages/packer-plugins/constants.ts
+++ b/packages/packer-plugins/constants.ts
@@ -1,0 +1,6 @@
+export const COMPONENT_TYPES = [
+  'builders',
+  'datasources',
+  'post-processors',
+  'provisioners',
+]

--- a/packages/packer-plugins/constants.ts
+++ b/packages/packer-plugins/constants.ts
@@ -1,3 +1,7 @@
+/**
+ * A list of Packer plugin component types. This maps to directory names within `./docs`:
+ * - @see https://github.com/hashicorp/packer-plugin-scaffolding/tree/main/docs
+ */
 export const COMPONENT_TYPES = [
   'builders',
   'datasources',

--- a/packages/packer-plugins/fetch-dev-plugin-docs.ts
+++ b/packages/packer-plugins/fetch-dev-plugin-docs.ts
@@ -1,0 +1,58 @@
+import path from 'path'
+import { validatePluginDocsFiles } from './validate-plugin-docs-files'
+import AdmZip from 'adm-zip'
+
+// Given a zipFile path,
+//
+// return [null, docsMdxFiles] if docs files
+// are successfully fetched and valid,
+// where docsMdxFiles is an array of { filePath, fileString } items.
+//
+// otherwise, return [err, null]
+// where err is an error message describing whether the
+// docs files were missing or invalid, with a path to resolution
+export async function fetchDevPluginDocs(zipFile: string) {
+  const [err, docsMdxFiles] = await parseZipFile(zipFile)
+  if (err) {
+    const errMsg = `Invalid plugin dev docs file ${zipFile}. ${err}`
+    throw new Error(errMsg)
+  }
+  return docsMdxFiles
+}
+
+// Given a docs.zip filepath,
+// which is a compressed "docs" folder,
+//
+// return [null, docsMdxFiles] if docs files
+// are successfully fetched and valid,
+// where docsMdxFiles is an array of { filePath, fileString } items.
+//
+// otherwise, return [err, null]
+// where err is an error message describing whether the
+// docs files were missing or invalid, with a path to resolution
+async function parseZipFile(
+  zipFile: string
+): Promise<
+  [null, { filePath: string; fileString: string }[]] | [string, null]
+> {
+  const responseZip = new AdmZip(zipFile)
+  const docsEntries = responseZip.getEntries()
+  // Validate the file paths within the "docs" folder
+  const docsFilePaths = docsEntries.map((e) => e.entryName)
+  const validationError = validatePluginDocsFiles(docsFilePaths)
+  if (validationError) {
+    return [validationError, null]
+  }
+  // If valid, filter for MDX files only, and return
+  // a { filePath, fileString } object for each mdx file
+  const docsMdxFiles = docsEntries
+    .filter((e) => {
+      return path.extname(e.entryName) === '.mdx'
+    })
+    .map((e) => {
+      const filePath = e.entryName
+      const fileString = e.getData().toString()
+      return { filePath, fileString }
+    })
+  return [null, docsMdxFiles]
+}

--- a/packages/packer-plugins/fetch-plugin-docs.ts
+++ b/packages/packer-plugins/fetch-plugin-docs.ts
@@ -1,0 +1,77 @@
+import fetch from 'isomorphic-unfetch'
+import { parseSourceZip } from './parse-source-zip'
+import { parseDocsZip } from './parse-docs-zip'
+import { RawPluginFile } from './types'
+
+interface Options {
+  repo: string
+  tag: string
+}
+
+// Given a repo and tag,
+//
+// return [null, docsMdxFiles] if docs files
+// are successfully fetched and valid,
+// where docsMdxFiles is an array of { filePath, fileString } items.
+//
+// otherwise, return [err, null]
+// where err is an error message describing whether the
+// docs files were missing or invalid, with a path to resolution
+async function fetchDocsFiles({ repo, tag }: Options) {
+  // If there's a docs.zip asset, we'll prefer that
+  const docsZipUrl =
+    tag === 'latest'
+      ? `https://github.com/${repo}/releases/latest/download/docs.zip`
+      : `https://github.com/${repo}/releases/download/${tag}/docs.zip`
+  const docsZipResponse = await fetch(docsZipUrl, { method: 'GET' })
+  const hasDocsZip = docsZipResponse.status === 200
+  // Note: early return!
+  if (hasDocsZip) {
+    return await parseDocsZip(docsZipResponse)
+  }
+  // Else if docs.zip is not present, and we only have the "latest" tag,
+  // then throw an error - we can't resolve the fallback source ZIP
+  // unless we resort to calling the GitHub API, which we do not want to do
+  if (tag === 'latest') {
+    const err = `Failed to fetch. Could not find "docs.zip" at ${docsZipUrl}. To fall back to parsing docs from "source", please provide a specific version tag instead of "${tag}".`
+    return [err, null]
+  }
+  // Else if docs.zip is not present, and we have a specific tag, then
+  // fall back to parsing docs files from the source zip
+  const sourceZipUrl = `https://github.com/${repo}/archive/${tag}.zip`
+  const sourceZipResponse = await fetch(sourceZipUrl, { method: 'GET' })
+  const missingSourceZip = sourceZipResponse.status !== 200
+  if (missingSourceZip) {
+    const err = `Failed to fetch. Could not find "docs.zip" at ${docsZipUrl}, and could not find fallback source ZIP at ${sourceZipUrl}. Please ensure one of these assets is available.`
+    return [err, null]
+  }
+  // Handle parsing from plugin source zip
+  return await parseSourceZip(sourceZipResponse)
+}
+
+const fetchPluginDocs = memoize(async function fetchPluginDocs({
+  repo,
+  tag,
+}: Options): Promise<RawPluginFile[]> {
+  const [err, docsMdxFiles] = await fetchDocsFiles({ repo, tag })
+  if (err) {
+    const errMsg = `Invalid plugin docs ${repo}, on release ${tag}. ${err}`
+    throw new Error(errMsg)
+  }
+  // TODO: fix the rest of the types so we don't have to cast here
+  return docsMdxFiles as RawPluginFile[]
+})
+
+function memoize<T extends (...args: any[]) => unknown>(method: T): T {
+  const cache: Record<string, ReturnType<T>> = {}
+  return async function (...args) {
+    const key = JSON.stringify(args)
+    if (!cache[key]) {
+      // @ts-expect-error -- not sure on the correct way to type `this` here
+      cache[key] = method.apply(this, args)
+    }
+    return cache[key]
+  } as T
+}
+
+export default fetchPluginDocs

--- a/packages/packer-plugins/fetch-plugin-docs.ts
+++ b/packages/packer-plugins/fetch-plugin-docs.ts
@@ -49,7 +49,7 @@ async function fetchDocsFiles({ repo, tag }: Options) {
   return await parseSourceZip(sourceZipResponse)
 }
 
-const fetchPluginDocs = memoize(async function fetchPluginDocs({
+export const fetchPluginDocs = memoize(async function fetchPluginDocs({
   repo,
   tag,
 }: Options): Promise<RawPluginFile[]> {
@@ -67,11 +67,8 @@ function memoize<T extends (...args: any[]) => unknown>(method: T): T {
   return async function (...args) {
     const key = JSON.stringify(args)
     if (!cache[key]) {
-      // @ts-expect-error -- not sure on the correct way to type `this` here
-      cache[key] = method.apply(this, args)
+      cache[key] = method(...args) as ReturnType<T>
     }
     return cache[key]
   } as T
 }
-
-export default fetchPluginDocs

--- a/packages/packer-plugins/index.ts
+++ b/packages/packer-plugins/index.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import grayMatter from 'gray-matter'
 import { fetchDevPluginDocs } from './fetch-dev-plugin-docs'
-import fetchPluginDocs from './fetch-plugin-docs'
+import { fetchPluginDocs } from './fetch-plugin-docs'
 import { PluginFile, PluginManifestEntry } from './types'
 
 export async function resolvePluginDocs(pluginManifest: PluginManifestEntry[]) {

--- a/packages/packer-plugins/index.ts
+++ b/packages/packer-plugins/index.ts
@@ -4,6 +4,25 @@ import { fetchDevPluginDocs } from './fetch-dev-plugin-docs'
 import { fetchPluginDocs } from './fetch-plugin-docs'
 import { PluginFile, PluginManifestEntry } from './types'
 
+/**
+ * Takes in a plugin manifest array and returns it decorated with file data for each plugin.
+ *
+ * Example:
+ *
+ * ```ts
+ * const result = resolvePluginDocs([
+ *   {
+ *     title: '1&1',
+ *     path: 'oneandone',
+ *     repo: 'hashicorp/packer-plugin-oneandone',
+ *     pluginTier: 'community',
+ *     version: 'latest',
+ *   },
+ * ])
+ *
+ * console.log(result.files) // [{ filePath, fileString, path, sourceUrl, title }]
+ * ```
+ */
 export async function resolvePluginDocs(pluginManifest: PluginManifestEntry[]) {
   return Promise.all(
     pluginManifest.map(async (manifestEntry) => {

--- a/packages/packer-plugins/index.ts
+++ b/packages/packer-plugins/index.ts
@@ -1,0 +1,63 @@
+import path from 'path'
+import grayMatter from 'gray-matter'
+import { fetchDevPluginDocs } from './fetch-dev-plugin-docs'
+import fetchPluginDocs from './fetch-plugin-docs'
+import { PluginFile, PluginManifestEntry } from './types'
+
+export async function resolvePluginDocs(pluginManifest: PluginManifestEntry[]) {
+  return Promise.all(
+    pluginManifest.map(async (manifestEntry) => {
+      const {
+        repo,
+        pluginTier,
+        zipFile = '',
+        version,
+        sourceBranch = 'main',
+      } = manifestEntry
+      // Determine the pluginTier, which can be set manually,
+      // or will be automatically set based on repo ownership
+      const pluginOwner = repo.split('/')[0]
+      const parsedPluginTier =
+        pluginTier || (pluginOwner === 'hashicorp' ? 'official' : 'community')
+      // Fetch the MDX files for the plugin entry
+      let docsMdxFiles = []
+      if (zipFile !== '') {
+        docsMdxFiles = (await fetchDevPluginDocs(zipFile)) ?? []
+      } else {
+        docsMdxFiles = await fetchPluginDocs({ repo, tag: version })
+      }
+
+      const files: PluginFile[] = docsMdxFiles.map((rawFile) => {
+        const { filePath, fileString } = rawFile
+        // Process into a NavLeaf, with a remoteFile attribute
+        const dirs = path.dirname(filePath).split('/')
+        const dirUrl = dirs.slice(2).join('/')
+        const basename = path.basename(filePath, path.extname(filePath))
+        // build urlPath
+        // note that this will be prefixed to get to our final path
+        const isIndexFile = basename === 'index'
+        const urlPath = isIndexFile ? dirUrl : path.join(dirUrl, basename)
+        // parse title, either from frontmatter or file name
+        const { data: frontmatter } = grayMatter(fileString)
+        const { nav_title, sidebar_title } = frontmatter
+        const title = nav_title || sidebar_title || basename
+        // construct sourceUrl (used for "Edit this page" link)
+        const sourceUrl = `https://github.com/${repo}/blob/${sourceBranch}/${filePath}`
+
+        return {
+          filePath,
+          fileString,
+          title,
+          path: urlPath,
+          sourceUrl,
+        }
+      })
+
+      return {
+        ...manifestEntry,
+        pluginTier: parsedPluginTier,
+        files,
+      }
+    })
+  )
+}

--- a/packages/packer-plugins/package.json
+++ b/packages/packer-plugins/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@hashicorp/platform-packer-plugins",
+  "version": "0.0.0",
+  "author": "HashiCorp",
+  "license": "MPL-2.0",
+  "publishConfig": {
+    "private": false
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.9",
+    "gray-matter": "^4.0.3",
+    "isomorphic-unfetch": "^3.1.0"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "^0.5.0"
+  }
+}

--- a/packages/packer-plugins/parse-docs-zip.ts
+++ b/packages/packer-plugins/parse-docs-zip.ts
@@ -1,0 +1,45 @@
+import path from 'path'
+import AdmZip from 'adm-zip'
+import { validatePluginDocsFiles } from './validate-plugin-docs-files'
+
+/*
+
+NOTE: used for default `docs.zip` release assets
+
+*/
+
+// Given a response from fetching a docs.zip file,
+// which is a compressed "docs" folder,
+//
+// return [null, docsMdxFiles] if docs files
+// are successfully fetched and valid,
+// where docsMdxFiles is an array of { filePath, fileString } items.
+//
+// otherwise, return [err, null]
+// where err is an error message describing whether the
+// docs files were missing or invalid, with a path to resolution
+export async function parseDocsZip(response: Response) {
+  // the file path from the repo root is the same as the zip entryName,
+  // which includes the docs directory as the first part of the path
+  const responseBuffer = Buffer.from(await response.arrayBuffer())
+  const responseZip = new AdmZip(responseBuffer)
+  const docsEntries = responseZip.getEntries()
+  // Validate the file paths within the "docs" folder
+  const docsFilePaths = docsEntries.map((e) => e.entryName)
+  const validationError = validatePluginDocsFiles(docsFilePaths)
+  if (validationError) {
+    return [validationError, null]
+  }
+  // If valid, filter for MDX files only, and return
+  // a { filePath, fileString } object for each mdx file
+  const docsMdxFiles = docsEntries
+    .filter((e) => {
+      return path.extname(e.entryName) === '.mdx'
+    })
+    .map((e) => {
+      const filePath = e.entryName
+      const fileString = e.getData().toString()
+      return { filePath, fileString }
+    })
+  return [null, docsMdxFiles]
+}

--- a/packages/packer-plugins/parse-source-zip.ts
+++ b/packages/packer-plugins/parse-source-zip.ts
@@ -1,0 +1,56 @@
+import path from 'path'
+import AdmZip from 'adm-zip'
+import { validatePluginDocsFiles } from './validate-plugin-docs-files'
+
+/*
+
+NOTE: used for fallback approach, where we parse from
+the full release archive
+
+*/
+
+// Given a response from fetching a source .zip file,
+// which contains a "docs" folder,
+//
+// return [null, docsMdxFiles] if docs files
+// are successfully fetched and valid,
+// where docsMdxFiles is an array of { filePath, fileString } items.
+//
+// otherwise, return [err, null]
+// where err is an error message describing whether the
+// docs files were missing or invalid, with a path to resolution
+export async function parseSourceZip(response: Response) {
+  const responseBuffer = Buffer.from(await response.arrayBuffer())
+  const responseZip = new AdmZip(responseBuffer)
+  const sourceEntries = responseZip.getEntries()
+  const docsEntries = sourceEntries.filter((entry) => {
+    // filter for zip entries in the docs subfolder only
+    const dirs = path.dirname(entry.entryName).split('/')
+    return dirs.length > 1 && dirs[1] === 'docs'
+  })
+  // Validate the file paths within the "docs" folder
+  const docsFilePaths = docsEntries.map((e) => {
+    // We need to remove the leading directory,
+    // which will be something like packer-plugin-docs-0.0.5
+    const filePath = e.entryName.split('/').slice(1).join('/')
+    return filePath
+  })
+  const validationError = validatePluginDocsFiles(docsFilePaths)
+  if (validationError) {
+    return [validationError, null]
+  }
+  // If valid, filter for MDX files only, and return
+  // a { filePath, fileString } object for each mdx file
+  const docsMdxFiles = docsEntries
+    .filter((e) => {
+      return path.extname(e.entryName) === '.mdx'
+    })
+    .map((e) => {
+      // We need to remove the leading directory,
+      // which will be something like packer-plugin-docs-0.0.5
+      const filePath = e.entryName.split('/').slice(1).join('/')
+      const fileString = e.getData().toString()
+      return { filePath, fileString }
+    })
+  return [null, docsMdxFiles]
+}

--- a/packages/packer-plugins/types.ts
+++ b/packages/packer-plugins/types.ts
@@ -1,0 +1,28 @@
+export interface PluginManifestEntry {
+  title: string
+  path: string
+  repo: string
+  version: string | 'latest'
+  pluginTier: 'community' | 'official'
+  archived?: boolean
+  isHcpPackerReady?: boolean
+  sourceBranch?: string
+  zipFile?: string
+}
+
+export interface PluginFile {
+  title: string
+  path: string
+  filePath: string
+  fileString: string
+  sourceUrl: string
+}
+
+export interface EnrichedPluginManifestEntry extends PluginManifestEntry {
+  files: PluginFile[]
+}
+
+export interface RawPluginFile {
+  filePath: string
+  fileString: string
+}

--- a/packages/packer-plugins/validate-plugin-docs-files.ts
+++ b/packages/packer-plugins/validate-plugin-docs-files.ts
@@ -1,0 +1,45 @@
+import path from 'path'
+import { COMPONENT_TYPES } from './constants'
+
+// Given an array of file paths within the "docs" folder,
+// validate that no unexpected files are being included,
+// and that there is at least one component subfolder
+// with at least one .mdx file within it.
+export function validatePluginDocsFiles(filePaths: string[]) {
+  function isValidPath(filePath: string) {
+    // Allow the docs root folder
+    const isDocsRoot = filePath === 'docs/'
+    // Allow component folders
+    const isComponentRoot = COMPONENT_TYPES.reduce((acc, type) => {
+      return acc || filePath === `docs/${type}/`
+    }, false)
+    // Allow .mdx files in component folders
+    const isComponentMdx = COMPONENT_TYPES.reduce((acc, type) => {
+      const mdxPathRegex = new RegExp(`^docs/${type}/(.*).mdx$`)
+      return acc || mdxPathRegex.test(filePath)
+    }, false)
+    // Allow docs/README.md files
+    const isDocsReadme = filePath == 'docs/README.md'
+    // Combine all allowed types
+    const isValidPath =
+      isDocsRoot || isComponentRoot || isComponentMdx || isDocsReadme
+    return isValidPath
+  }
+  const invalidPaths = filePaths.filter((f) => !isValidPath(f))
+  if (invalidPaths.length > 0) {
+    return `Found invalid files or folders in the docs directory: ${JSON.stringify(
+      invalidPaths
+    )}. Please ensure the docs folder contains only component subfolders and .mdx files within those subfolders. Valid component types are: ${JSON.stringify(
+      COMPONENT_TYPES
+    )}.`
+  }
+  const validPaths = filePaths.filter(isValidPath)
+  const mdxFiles = validPaths.filter((fp) => path.extname(fp) === '.mdx')
+  const isMissingDocs = mdxFiles.length == 0
+  if (isMissingDocs) {
+    return `Could not find valid .mdx files. Please ensure there is at least one component subfolder in the docs directory, which contains at least one .mdx file. Valid component types are: ${JSON.stringify(
+      COMPONENT_TYPES
+    )}.`
+  }
+  return null
+}

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ Current packages:
 - [`@hashicorp/platform-docs-mdx`](/packages/docs-mdx)
 - [`@hashicorp/platform-markdown-utils`](/packages/markdown-utils)
 - [`@hashicorp/platform-nextjs-plugin`](/packages/nextjs-plugin)
+- [`@hashicorp/platform-packer-plugins`](/packages/packer-plugins)
 - [`@hashicorp/platform-product-meta`](/packages/product-meta)
 - [`@hashicorp/platform-remark-plugins`](/packages/remark-plugins)
 - [`@hashicorp/platform-runtime-error-monitoring`](/packages/runtime-error-monitoring)


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->
Abstracting out the utilities related to fetching content for packer plugins defined in a manifest file. I need access to these so that I can properly execute search indexing for packer in our shared workflows.

This was almost entirely lifted from https://github.com/hashicorp/dev-portal/tree/477e007fa880922170643001b1811aa49577fa83/src/components/_proxied-dot-io/packer/remote-plugin-docs, with a conversion to TS along the way.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
