### PR TITLE
Add no-nested-ternary and no-unneeded-ternary to ESLint rules

### DIFF
--- a/packages/cli/config/.eslintrc.js
+++ b/packages/cli/config/.eslintrc.js
@@ -126,6 +126,12 @@ module.exports = {
   rules: {
     // An odd rule that leads to odd code patterns, we are opting to disable it for our projects (https://app.asana.com/0/1100423001970639/1199667739287945/f)
     'no-prototype-builtins': 'off',
+    
+    // Nested ternaries make code harder to understand (set to "warn" for backwards-compatibility)
+    'no-nested-ternary': 'warn',
+    
+    // Unneeded ternaries should be replaced with easier to understand expressions (set to "warn" for backwards-compatibility)
+    'no-unneeded-ternary': 'warn',
 
     // Not necessary in Next.js (https://spectrum.chat/next-js/general/react-must-be-in-scope-when-using-jsx~6193ef62-4d5e-4681-8f51-8c7bf6b9d56d)
     'react/react-in-jsx-scope': 'off',


### PR DESCRIPTION
## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->

- Adds the [`no-nested-ternary`](https://eslint.org/docs/rules/no-nested-ternary) and [`no-unneeded-ternary`](https://eslint.org/docs/rules/no-unneeded-ternary) rules to our widely shared ESLint config. Also adds comments above them explaining why.
- Both rules are set to "warn" so they don't break other projects. The long term goal would be to set these to "error".

**Problems these rules solve:**

- `no-nested-ternary` is used for prohibiting nested ternaries, which I have a very difficult time reading and understanding, even after reading the same one multiple times.
- `no-unneeded-ternary` encourages simpler operations when a ternary has two boolean values in it or when something like `x ? x : 1` is written instead of `x || 1`. Saw it I was reading the docs for `no-nested-ternary` and figured we could benefit from it as well!

## PR Checklist 🚀

- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
