### PR TITLE
feat(anchor-links): put target id on heading element

### DIFF
--- a/.changeset/beige-ladybugs-laugh.md
+++ b/.changeset/beige-ladybugs-laugh.md
@@ -1,5 +1,5 @@
 ---
-'@hashicorp/platform-markdown-utils': minor
+'@hashicorp/platform-markdown-utils': major
 ---
 
 Bumps to new anchor-links plugin, sets id on heading, not extra element.

--- a/.changeset/beige-ladybugs-laugh.md
+++ b/.changeset/beige-ladybugs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-markdown-utils': minor
+---
+
+Bumps to new anchor-links plugin, sets id on heading, not extra element.

--- a/.changeset/beige-ladybugs-laugh.md
+++ b/.changeset/beige-ladybugs-laugh.md
@@ -1,5 +1,5 @@
 ---
-'@hashicorp/platform-markdown-utils': major
+'@hashicorp/platform-markdown-utils': minor
 ---
 
 Bumps to new anchor-links plugin, sets id on heading, not extra element.

--- a/.changeset/cold-peas-tap.md
+++ b/.changeset/cold-peas-tap.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-remark-plugins': minor
+---
+
+Breaking change. Replaces \_\_target-h elements, makes heading element the target, by setting their ID global attribute.

--- a/.changeset/cold-peas-tap.md
+++ b/.changeset/cold-peas-tap.md
@@ -1,5 +1,5 @@
 ---
-'@hashicorp/platform-remark-plugins': major
+'@hashicorp/platform-remark-plugins': minor
 ---
 
 Breaking change. Replaces \_\_target-h elements, makes heading element the target, by setting their ID global attribute.

--- a/.changeset/cold-peas-tap.md
+++ b/.changeset/cold-peas-tap.md
@@ -1,5 +1,5 @@
 ---
-'@hashicorp/platform-remark-plugins': minor
+'@hashicorp/platform-remark-plugins': major
 ---
 
 Breaking change. Replaces \_\_target-h elements, makes heading element the target, by setting their ID global attribute.

--- a/.changeset/spicy-pigs-retire.md
+++ b/.changeset/spicy-pigs-retire.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-types': patch
+---
+
+Adds @hashicorp/platform-remark-plugins, which replaces @hashicorp/remark-plugins.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26413,7 +26413,7 @@
       "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/platform-remark-plugins": "1.0.0-canary-2022571993",
+        "@hashicorp/platform-remark-plugins": "^1.0.0-canary-2022571993",
         "@hashicorp/platform-types": "^0.2.0",
         "@mapbox/rehype-prism": "^0.6.0",
         "@mdx-js/react": "1.6.22",
@@ -29789,7 +29789,7 @@
     "@hashicorp/platform-markdown-utils": {
       "version": "file:packages/markdown-utils",
       "requires": {
-        "@hashicorp/platform-remark-plugins": "1.0.0-canary-2022571993",
+        "@hashicorp/platform-remark-plugins": "0.1.0",
         "@hashicorp/platform-types": "^0.2.0",
         "@mapbox/rehype-prism": "^0.6.0",
         "@mdx-js/react": "1.6.22",
@@ -29799,8 +29799,7 @@
       },
       "dependencies": {
         "@hashicorp/platform-remark-plugins": {
-          "version": "1.0.0-canary-2022571993",
-          "resolved": "https://registry.npmjs.org/@hashicorp/platform-remark-plugins/-/platform-remark-plugins-1.0.0-canary-2022571993.tgz",
+          "version": "https://registry.npmjs.org/@hashicorp/platform-remark-plugins/-/platform-remark-plugins-1.0.0-canary-2022571993.tgz",
           "integrity": "sha512-3pTdLMT9vps9pc5ASdEx8seCz6E9OS8asdu59TcWmQUvk1JSbk7LKQr1ysgGPnYGwkVcM+MCp/tMUWzN4+zHOw==",
           "requires": {
             "remark": "^14.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,18 +287,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.12.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.12.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -349,16 +337,6 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.12.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -448,19 +426,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz",
       "integrity": "sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==",
       "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.14.5",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -2674,14 +2639,6 @@
       },
       "peerDependencies": {
         "react": "^16.13.1 || ^17.0.0"
-      }
-    },
-    "node_modules/@mdx-js/util": {
-      "version": "1.6.22",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
@@ -6204,14 +6161,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/collapse-white-space": {
-      "version": "1.0.6",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -9105,17 +9054,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/github-slugger": {
-      "version": "1.3.0",
-      "license": "ISC",
-      "dependencies": {
-        "emoji-regex": ">=6.0.0 <=6.1.1"
-      }
-    },
-    "node_modules/github-slugger/node_modules/emoji-regex": {
-      "version": "6.1.1",
-      "license": "MIT"
-    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -10654,13 +10592,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-alphanumeric": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-alphanumerical": {
       "version": "1.0.4",
       "license": "MIT",
@@ -11140,27 +11071,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-whitespace-character": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-word-character": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-wsl": {
@@ -13658,14 +13573,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/markdown-escapes": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/markdown-extensions": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
@@ -13673,17 +13580,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/markdown-table": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -13701,17 +13597,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/mdast-util-compact": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -18550,19 +18435,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/remark": {
-      "version": "12.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "remark-parse": "^8.0.0",
-        "remark-stringify": "^8.0.0",
-        "unified": "^9.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-html": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-15.0.0.tgz",
@@ -18947,153 +18819,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-mdx": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.22.tgz",
-      "integrity": "sha512-phMHBJgeV76uyFkH4rvzCftLfKCr2RZuF+/gmVcaKrpsihyzmhXjA0BEMDaPTXG5y8qZOKPVo83NAOX01LPnOQ==",
-      "dependencies": {
-        "@babel/core": "7.12.9",
-        "@babel/helper-plugin-utils": "7.10.4",
-        "@babel/plugin-proposal-object-rest-spread": "7.12.1",
-        "@babel/plugin-syntax-jsx": "7.12.1",
-        "@mdx-js/util": "1.6.22",
-        "is-alphabetical": "1.0.4",
-        "remark-parse": "8.0.3",
-        "unified": "9.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-mdx/node_modules/@babel/core": {
-      "version": "7.12.9",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
-        "@babel/helper-module-transforms": "^7.12.1",
-        "@babel/helpers": "^7.12.5",
-        "@babel/parser": "^7.12.7",
-        "@babel/template": "^7.12.7",
-        "@babel/traverse": "^7.12.9",
-        "@babel/types": "^7.12.7",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/remark-mdx/node_modules/@babel/helper-plugin-utils": {
-      "version": "7.10.4",
-      "license": "MIT"
-    },
-    "node_modules/remark-mdx/node_modules/remark-parse": {
-      "version": "8.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^2.0.0",
-        "vfile-location": "^3.0.0",
-        "xtend": "^4.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-mdx/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/remark-mdx/node_modules/source-map": {
-      "version": "0.5.7",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/remark-parse": {
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^0.8.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-stringify": {
-      "version": "8.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^2.0.0",
-        "mdast-util-compact": "^2.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^3.0.0",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark/node_modules/remark-parse": {
-      "version": "8.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "ccount": "^1.0.0",
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^2.0.0",
-        "vfile-location": "^3.0.0",
-        "xtend": "^4.0.1"
       },
       "funding": {
         "type": "opencollective",
@@ -20683,14 +20413,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/state-toggle": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/static-extend": {
@@ -22500,39 +22222,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/to-vfile": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^2.0.0",
-        "vfile": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/to-vfile/node_modules/is-buffer": {
-      "version": "2.0.5",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.0",
       "license": "MIT",
@@ -22584,9 +22273,6 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
-    "node_modules/trim": {
-      "version": "0.0.1"
-    },
     "node_modules/trim-newlines": {
       "version": "1.0.0",
       "license": "MIT",
@@ -22602,14 +22288,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/trim-trailing-lines": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/trough": {
@@ -22931,18 +22609,6 @@
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
-    "node_modules/unherit": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.0",
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/unidecode": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
@@ -23064,11 +22730,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-flatmap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-flatmap/-/unist-util-flatmap-1.0.0.tgz",
-      "integrity": "sha512-IG32jcKJlhARCYT2LsYPJWdoXYkzz3ESAdl1aa2hn9Auh+cgUmU6wgkII4yCc/1GgeWibRdELdCZh/p3QKQ1dQ=="
-    },
     "node_modules/unist-util-generated": {
       "version": "1.1.6",
       "license": "MIT",
@@ -23080,18 +22741,6 @@
     "node_modules/unist-util-is": {
       "version": "4.1.0",
       "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-map": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "object-assign": "^4.0.0"
-      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -23111,17 +22760,6 @@
       "integrity": "sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==",
       "dependencies": {
         "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26209,11 +25847,11 @@
     },
     "packages/markdown-utils": {
       "name": "@hashicorp/platform-markdown-utils",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/platform-types": "^0.1.0",
-        "@hashicorp/remark-plugins": "^3.3.1",
+        "@hashicorp/platform-remark-plugins": "^0.1.0",
+        "@hashicorp/platform-types": "^0.2.0",
         "@mapbox/rehype-prism": "^0.6.0",
         "@mdx-js/react": "1.6.22",
         "rehype-katex": "^5.0.0",
@@ -26222,22 +25860,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.x"
-      }
-    },
-    "packages/markdown-utils/node_modules/@hashicorp/remark-plugins": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-3.3.1.tgz",
-      "integrity": "sha512-7xThpsBFWasdC/E+E/BAjHxMYqyCcQFiTVspvhBzN51meiQIacVCnyAox/lyvwWiP4N3Yj/ruH4UsR2ifskNeA==",
-      "dependencies": {
-        "@mdx-js/util": "1.6.22",
-        "github-slugger": "^1.3.0",
-        "remark": "12.0.1",
-        "remark-mdx": "1.6.22",
-        "to-vfile": "^6.1.0",
-        "unist-util-flatmap": "^1.0.0",
-        "unist-util-is": "^4.0.2",
-        "unist-util-map": "^2.0.1",
-        "unist-util-visit": "^2.0.3"
       }
     },
     "packages/markdown-utils/node_modules/@mapbox/rehype-prism": {
@@ -26432,7 +26054,7 @@
         "postcss-normalize": "10.0.1"
       },
       "devDependencies": {
-        "@hashicorp/platform-types": "^0.1.0",
+        "@hashicorp/platform-types": "^0.2.0",
         "@types/postcss-normalize": "^9.0.1",
         "@types/postcss-preset-env": "^6.7.0",
         "@types/webpack": "^4.41.26"
@@ -27386,7 +27008,7 @@
     },
     "packages/types": {
       "name": "@hashicorp/platform-types",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@types/segment-analytics": "^0.0.33",
@@ -27607,14 +27229,6 @@
     "@babel/parser": {
       "version": "7.14.1"
     },
-    "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.12.1",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.12.1"
-      }
-    },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -27653,12 +27267,6 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.12.1",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -27720,12 +27328,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz",
       "integrity": "sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==",
       "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
-    "@babel/plugin-transform-parameters": {
-      "version": "7.14.5",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -29810,8 +29412,8 @@
     "@hashicorp/platform-markdown-utils": {
       "version": "file:packages/markdown-utils",
       "requires": {
-        "@hashicorp/platform-types": "^0.1.0",
-        "@hashicorp/remark-plugins": "^3.3.1",
+        "@hashicorp/platform-remark-plugins": "^0.1.0",
+        "@hashicorp/platform-types": "^0.2.0",
         "@mapbox/rehype-prism": "^0.6.0",
         "@mdx-js/react": "1.6.22",
         "rehype-katex": "^5.0.0",
@@ -29819,22 +29421,6 @@
         "remark-rehype": "^7.0.0"
       },
       "dependencies": {
-        "@hashicorp/remark-plugins": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/@hashicorp/remark-plugins/-/remark-plugins-3.3.1.tgz",
-          "integrity": "sha512-7xThpsBFWasdC/E+E/BAjHxMYqyCcQFiTVspvhBzN51meiQIacVCnyAox/lyvwWiP4N3Yj/ruH4UsR2ifskNeA==",
-          "requires": {
-            "@mdx-js/util": "1.6.22",
-            "github-slugger": "^1.3.0",
-            "remark": "12.0.1",
-            "remark-mdx": "1.6.22",
-            "to-vfile": "^6.1.0",
-            "unist-util-flatmap": "^1.0.0",
-            "unist-util-is": "^4.0.2",
-            "unist-util-map": "^2.0.1",
-            "unist-util-visit": "^2.0.3"
-          }
-        },
         "@mapbox/rehype-prism": {
           "version": "0.6.0",
           "requires": {
@@ -29900,7 +29486,7 @@
       "version": "file:packages/nextjs-plugin",
       "requires": {
         "@hashicorp/next-optimized-images": "0.2.0",
-        "@hashicorp/platform-types": "^0.1.0",
+        "@hashicorp/platform-types": "^0.2.0",
         "@next/bundle-analyzer": "10.0.3",
         "@types/postcss-normalize": "^9.0.1",
         "@types/postcss-preset-env": "^6.7.0",
@@ -31459,9 +31045,6 @@
     "@mdx-js/react": {
       "version": "1.6.22",
       "requires": {}
-    },
-    "@mdx-js/util": {
-      "version": "1.6.22"
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -33937,9 +33520,6 @@
         }
       }
     },
-    "collapse-white-space": {
-      "version": "1.0.6"
-    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -35965,17 +35545,6 @@
     "get-value": {
       "version": "2.0.6"
     },
-    "github-slugger": {
-      "version": "1.3.0",
-      "requires": {
-        "emoji-regex": ">=6.0.0 <=6.1.1"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "6.1.1"
-        }
-      }
-    },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -37003,9 +36572,6 @@
     "is-alphabetical": {
       "version": "1.0.4"
     },
-    "is-alphanumeric": {
-      "version": "1.0.0"
-    },
     "is-alphanumerical": {
       "version": "1.0.4",
       "requires": {
@@ -37260,14 +36826,8 @@
         "call-bind": "^1.0.2"
       }
     },
-    "is-whitespace-character": {
-      "version": "1.0.4"
-    },
     "is-windows": {
       "version": "1.0.2"
-    },
-    "is-word-character": {
-      "version": "1.0.4"
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -39179,20 +38739,11 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-escapes": {
-      "version": "1.0.4"
-    },
     "markdown-extensions": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
       "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==",
       "dev": true
-    },
-    "markdown-table": {
-      "version": "2.0.0",
-      "requires": {
-        "repeat-string": "^1.0.0"
-      }
     },
     "mathml-tag-names": {
       "version": "2.1.3"
@@ -39203,12 +38754,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "mdast-util-compact": {
-      "version": "2.0.1",
-      "requires": {
-        "unist-util-visit": "^2.0.0"
       }
     },
     "mdast-util-from-markdown": {
@@ -42384,37 +41929,6 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
-    "remark": {
-      "version": "12.0.1",
-      "requires": {
-        "remark-parse": "^8.0.0",
-        "remark-stringify": "^8.0.0",
-        "unified": "^9.0.0"
-      },
-      "dependencies": {
-        "remark-parse": {
-          "version": "8.0.3",
-          "requires": {
-            "ccount": "^1.0.0",
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^2.0.0",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^2.0.0",
-            "vfile-location": "^3.0.0",
-            "xtend": "^4.0.1"
-          }
-        }
-      }
-    },
     "remark-html": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-15.0.0.tgz",
@@ -42663,97 +42177,10 @@
         "micromark-extension-math": "^0.1.0"
       }
     },
-    "remark-mdx": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.22.tgz",
-      "integrity": "sha512-phMHBJgeV76uyFkH4rvzCftLfKCr2RZuF+/gmVcaKrpsihyzmhXjA0BEMDaPTXG5y8qZOKPVo83NAOX01LPnOQ==",
-      "requires": {
-        "@babel/core": "7.12.9",
-        "@babel/helper-plugin-utils": "7.10.4",
-        "@babel/plugin-proposal-object-rest-spread": "7.12.1",
-        "@babel/plugin-syntax-jsx": "7.12.1",
-        "@mdx-js/util": "1.6.22",
-        "is-alphabetical": "1.0.4",
-        "remark-parse": "8.0.3",
-        "unified": "9.2.0"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.12.9",
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.12.5",
-            "@babel/helper-module-transforms": "^7.12.1",
-            "@babel/helpers": "^7.12.5",
-            "@babel/parser": "^7.12.7",
-            "@babel/template": "^7.12.7",
-            "@babel/traverse": "^7.12.9",
-            "@babel/types": "^7.12.7",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.19",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-plugin-utils": {
-          "version": "7.10.4"
-        },
-        "remark-parse": {
-          "version": "8.0.3",
-          "requires": {
-            "ccount": "^1.0.0",
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^2.0.0",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^2.0.0",
-            "vfile-location": "^3.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1"
-        },
-        "source-map": {
-          "version": "0.5.7"
-        }
-      }
-    },
     "remark-parse": {
       "version": "9.0.0",
       "requires": {
         "mdast-util-from-markdown": "^0.8.0"
-      }
-    },
-    "remark-stringify": {
-      "version": "8.1.1",
-      "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^2.0.0",
-        "mdast-util-compact": "^2.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^3.0.0",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -43874,9 +43301,6 @@
           "peer": true
         }
       }
-    },
-    "state-toggle": {
-      "version": "1.0.3"
     },
     "static-extend": {
       "version": "0.1.2",
@@ -45124,18 +44548,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "to-vfile": {
-      "version": "6.1.0",
-      "requires": {
-        "is-buffer": "^2.0.0",
-        "vfile": "^4.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.5"
-        }
-      }
-    },
     "toidentifier": {
       "version": "1.0.0"
     },
@@ -45174,9 +44586,6 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
-    "trim": {
-      "version": "0.0.1"
-    },
     "trim-newlines": {
       "version": "1.0.0"
     },
@@ -45185,9 +44594,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
-    },
-    "trim-trailing-lines": {
-      "version": "1.1.4"
     },
     "trough": {
       "version": "1.0.5"
@@ -45397,13 +44803,6 @@
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
       "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
-    "unherit": {
-      "version": "1.1.3",
-      "requires": {
-        "inherits": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "unidecode": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
@@ -45473,23 +44872,11 @@
         "unist-util-is": "^4.0.0"
       }
     },
-    "unist-util-flatmap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-flatmap/-/unist-util-flatmap-1.0.0.tgz",
-      "integrity": "sha512-IG32jcKJlhARCYT2LsYPJWdoXYkzz3ESAdl1aa2hn9Auh+cgUmU6wgkII4yCc/1GgeWibRdELdCZh/p3QKQ1dQ=="
-    },
     "unist-util-generated": {
       "version": "1.1.6"
     },
     "unist-util-is": {
       "version": "4.1.0"
-    },
-    "unist-util-map": {
-      "version": "2.0.1",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "object-assign": "^4.0.0"
-      }
     },
     "unist-util-position": {
       "version": "3.1.0"
@@ -45500,12 +44887,6 @@
       "integrity": "sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==",
       "requires": {
         "@types/unist": "^2.0.0"
-      }
-    },
-    "unist-util-remove-position": {
-      "version": "2.0.1",
-      "requires": {
-        "unist-util-visit": "^2.0.0"
       }
     },
     "unist-util-stringify-position": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2441,20 +2441,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/@mdx-js/mdx/node_modules/remark-mdx": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.0.0-rc.2.tgz",
-      "integrity": "sha512-TMgFSEVx42/YzJWjDY+GKw7CGSbp3XKqBraXPxFS27r8iD9U6zuOZKXH4MoLl9JqiTOmQi0M1zJwT2YhPs32ug==",
-      "dev": true,
-      "dependencies": {
-        "mdast-util-mdx": "^1.0.0",
-        "micromark-extension-mdxjs": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/@mdx-js/mdx/node_modules/remark-parse": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.0.tgz",
@@ -6729,6 +6715,27 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decode-named-character-reference/node_modules/character-entities": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
+      "integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
@@ -13628,12 +13635,12 @@
       }
     },
     "node_modules/mdast-util-mdx": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-1.1.0.tgz",
-      "integrity": "sha512-leKb9uG7laXdyFlTleYV4ZEaCpsxeU1LlkkR/xp35pgKrfV1Y0fNCuOw9vaRc2a9YDpH22wd145Wt7UY5yzeZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-2.0.0.tgz",
+      "integrity": "sha512-M09lW0CcBT1VrJUaF/PYxemxxHa7SLDHdSn94Q9FhxjCQfuW7nMAWKWimTmA3OyDMSTH981NN1csW1X+HPSluw==",
       "dependencies": {
         "mdast-util-mdx-expression": "^1.0.0",
-        "mdast-util-mdx-jsx": "^1.0.0",
+        "mdast-util-mdx-jsx": "^2.0.0",
         "mdast-util-mdxjs-esm": "^1.0.0"
       },
       "funding": {
@@ -13654,14 +13661,16 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.1.2.tgz",
-      "integrity": "sha512-1/bDUZvPGNVxiAjrVsehMZTaNomihpbIMoMr8/UcAQ4h7itDFhN93LtO9XzQPlEM+CMueCoRYGQfl7N+5R+8Mg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.0.1.tgz",
+      "integrity": "sha512-oPC7/smPBf7vxnvIYH5y3fPo2lw1rdrswFfSb4i0GTAXRUQv7JUU/t/hbp07dgGdUFTSDOHm5DNamhNg/s2Hrg==",
       "dependencies": {
         "@types/estree-jsx": "^0.0.1",
+        "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.0.0",
-        "parse-entities": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "parse-entities": "^4.0.0",
         "stringify-entities": "^4.0.0",
         "unist-util-remove-position": "^4.0.0",
         "unist-util-stringify-position": "^3.0.0",
@@ -13670,6 +13679,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx/node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mdast-util-mdx-jsx/node_modules/character-entities": {
@@ -13758,9 +13776,9 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx/node_modules/mdast-util-to-markdown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.4.tgz",
-      "integrity": "sha512-Wive3NvrNS4OY5yYKBADdK1QSlbJUZyZ2ssanITUzNQ7sxMfBANTVjLrAA9BFXshaeG9G77xpOK/z+TTret5Hg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
+      "integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -13785,14 +13803,15 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx/node_modules/parse-entities": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
-      "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
+      "integrity": "sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
         "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
         "is-alphanumerical": "^2.0.0",
         "is-decimal": "^2.0.0",
         "is-hexadecimal": "^2.0.0"
@@ -13803,9 +13822,9 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx/node_modules/stringify-entities": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.2.tgz",
-      "integrity": "sha512-MTxTVcEkorNtBbNpoFJPEh0kKdM6+QbMjLbaxmvaPMmayOXdr/AIVIIJX7FReUVweRBFJfZepK4A4AKgwuFpMQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -13824,23 +13843,10 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-mdx-jsx/node_modules/unist-util-remove-position": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.1.tgz",
-      "integrity": "sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "unist-util-visit": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-mdx-jsx/node_modules/unist-util-stringify-position": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
-      "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -13877,9 +13883,9 @@
       }
     },
     "node_modules/mdast-util-mdx-jsx/node_modules/vfile-message": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
-      "integrity": "sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -18435,6 +18441,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
+      "integrity": "sha512-A3ARm2V4BgiRXaUo5K0dRvJ1lbogrbXnhkJRmD0yw092/Yl0kOCZt1k9ZeElEwkZsWGsMumz6qL5MfNJH9nOBA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-stringify": "^10.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-html": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-15.0.0.tgz",
@@ -18819,11 +18840,417 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-mdx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.1.1.tgz",
+      "integrity": "sha512-0wXdEITnFyjLquN3VvACNLzbGzWM5ujzTvfgOkONBZgSFJ7ezLLDaTWqf6H9eUgVITEP8asp6LJ0W/X090dXBg==",
+      "dependencies": {
+        "mdast-util-mdx": "^2.0.0",
+        "micromark-extension-mdxjs": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.2.tgz",
+      "integrity": "sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/is-plain-obj": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+      "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/longest-streak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
+      "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/mdast-util-to-markdown": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
+      "integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/mdast-util-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-stringify-position": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-visit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+      "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/unist-util-visit-parents": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+      "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/vfile": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+      "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/vfile-message": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/zwitch": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
+      "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/remark/node_modules/is-plain-obj": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+      "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark/node_modules/mdast-util-from-markdown": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
+      "integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark/node_modules/mdast-util-to-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark/node_modules/micromark": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.10.tgz",
+      "integrity": "sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark/node_modules/remark-parse": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
+      "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark/node_modules/trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark/node_modules/unist-util-stringify-position": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark/node_modules/vfile": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+      "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark/node_modules/vfile-message": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22222,6 +22649,81 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-vfile": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.3.tgz",
+      "integrity": "sha512-QO0A9aE6Z/YkmQadJ0syxpmNXtcQiu0qAtCKYKD5cS3EfgfFTAXfgLX6AOaBrSfWSek5nfsMf3gBZ9KGVFcLuw==",
+      "dependencies": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^5.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/to-vfile/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-vfile/node_modules/unist-util-stringify-position": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/to-vfile/node_modules/vfile": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+      "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/to-vfile/node_modules/vfile-message": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.0",
       "license": "MIT",
@@ -22746,6 +23248,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-map": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.1.1.tgz",
+      "integrity": "sha512-n36sjBn4ibPtAzrFweyT4FOcCI/UdzboaEcsZvwoAyD/gVw5B3OLlMBySePMO6r+uzjxQEyRll2akfVaT4SHhw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-position": {
       "version": "3.1.0",
       "license": "MIT",
@@ -22760,6 +23274,55 @@
       "integrity": "sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==",
       "dependencies": {
         "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.1.tgz",
+      "integrity": "sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position/node_modules/unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position/node_modules/unist-util-visit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+      "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position/node_modules/unist-util-visit-parents": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+      "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -25850,7 +26413,7 @@
       "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@hashicorp/platform-remark-plugins": "^0.1.0",
+        "@hashicorp/platform-remark-plugins": "1.0.0-canary-2022571993",
         "@hashicorp/platform-types": "^0.2.0",
         "@mapbox/rehype-prism": "^0.6.0",
         "@mdx-js/react": "1.6.22",
@@ -25860,6 +26423,48 @@
       },
       "peerDependencies": {
         "react": ">= 16.x"
+      }
+    },
+    "packages/markdown-utils/node_modules/@hashicorp/platform-remark-plugins": {
+      "version": "1.0.0-canary-2022571993",
+      "resolved": "https://registry.npmjs.org/@hashicorp/platform-remark-plugins/-/platform-remark-plugins-1.0.0-canary-2022571993.tgz",
+      "integrity": "sha512-3pTdLMT9vps9pc5ASdEx8seCz6E9OS8asdu59TcWmQUvk1JSbk7LKQr1ysgGPnYGwkVcM+MCp/tMUWzN4+zHOw==",
+      "dependencies": {
+        "remark": "^14.0.1",
+        "remark-html": "^15.0.0",
+        "remark-mdx": "^2.0.0-rc.2",
+        "remark-stringify": "^10.0.1",
+        "to-vfile": "^7.2.2",
+        "unist-builder": "^3.0.0",
+        "unist-util-is": "^5.1.1",
+        "unist-util-map": "^3.0.0",
+        "unist-util-visit": "^4.1.0"
+      }
+    },
+    "packages/markdown-utils/node_modules/@hashicorp/platform-remark-plugins/node_modules/unist-builder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.0.tgz",
+      "integrity": "sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/markdown-utils/node_modules/@hashicorp/platform-remark-plugins/node_modules/unist-util-visit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+      "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "packages/markdown-utils/node_modules/@mapbox/rehype-prism": {
@@ -25944,6 +26549,28 @@
       "integrity": "sha512-uqQ/VbaTdxyu/da6npHAso6hA00cMqhA3a59RziQdOLN2KEIkPykAVy52IcmZEVTuauXO0VtpxkyCey4phtHzQ==",
       "dependencies": {
         "mdast-util-to-hast": "^9.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/markdown-utils/node_modules/unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "packages/markdown-utils/node_modules/unist-util-visit-parents": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+      "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -26258,6 +26885,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -26268,15 +26896,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
       "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "packages/remark-plugins/node_modules/character-entities": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
-      "integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -26296,15 +26915,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "packages/remark-plugins/node_modules/character-reference-invalid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -26376,32 +26987,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "packages/remark-plugins/node_modules/is-alphabetical": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "packages/remark-plugins/node_modules/is-alphanumerical": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-      "dependencies": {
-        "is-alphabetical": "^2.0.0",
-        "is-decimal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "packages/remark-plugins/node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -26420,42 +27010,16 @@
         "node": ">=4"
       }
     },
-    "packages/remark-plugins/node_modules/is-decimal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "packages/remark-plugins/node_modules/is-hexadecimal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "packages/remark-plugins/node_modules/is-plain-obj": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
       "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/remark-plugins/node_modules/longest-streak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
-      "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/remark-plugins/node_modules/mdast-util-definitions": {
@@ -26502,29 +27066,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "packages/remark-plugins/node_modules/mdast-util-from-markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.1.0.tgz",
-      "integrity": "sha512-Mex7IIeIKRpGYNNywpxTfPhfFBTxBL5IVacPMU6GjYF+EkIvy++19cBgxVFyHVd2JpC/chG2IKGqZLffoo7Q1g==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "mdast-util-to-string": "^3.1.0",
-        "micromark": "^3.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "parse-entities": "^3.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "uvu": "^0.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "packages/remark-plugins/node_modules/mdast-util-to-hast": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.0.0.tgz",
@@ -26545,85 +27086,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/remark-plugins/node_modules/mdast-util-to-markdown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.4.tgz",
-      "integrity": "sha512-Wive3NvrNS4OY5yYKBADdK1QSlbJUZyZ2ssanITUzNQ7sxMfBANTVjLrAA9BFXshaeG9G77xpOK/z+TTret5Hg==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-to-string": "^3.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "unist-util-visit": "^4.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/remark-plugins/node_modules/mdast-util-to-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
-      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/remark-plugins/node_modules/micromark": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.7.tgz",
-      "integrity": "sha512-67ipZ2CzQVsDyH1kqNLh7dLwe5QMPJwjFBGppW7JCLByaSc6ZufV0ywPOxt13MIDAzzmj3wctDL6Ov5w0fOHXw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "micromark-core-commonmark": "^1.0.1",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-combine-extensions": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "parse-entities": "^3.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "packages/remark-plugins/node_modules/parse-entities": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
-      "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
-      "dependencies": {
-        "@types/unist": "^2.0.0",
-        "character-entities": "^2.0.0",
-        "character-entities-legacy": "^3.0.0",
-        "character-reference-invalid": "^2.0.0",
-        "is-alphanumerical": "^2.0.0",
-        "is-decimal": "^2.0.0",
-        "is-hexadecimal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/remark-plugins/node_modules/property-information": {
@@ -26651,48 +27113,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "packages/remark-plugins/node_modules/remark": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.1.tgz",
-      "integrity": "sha512-7zLG3u8EUjOGuaAS9gUNJPD2j+SqDqAFHv2g6WMpE5CU9rZ6e3IKDM12KHZ3x+YNje+NMAuN55yx8S5msGSx7Q==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "remark-parse": "^10.0.0",
-        "remark-stringify": "^10.0.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/remark-plugins/node_modules/remark-mdx": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.0.0-rc.2.tgz",
-      "integrity": "sha512-TMgFSEVx42/YzJWjDY+GKw7CGSbp3XKqBraXPxFS27r8iD9U6zuOZKXH4MoLl9JqiTOmQi0M1zJwT2YhPs32ug==",
-      "dependencies": {
-        "mdast-util-mdx": "^1.0.0",
-        "micromark-extension-mdxjs": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/remark-plugins/node_modules/remark-parse": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.0.tgz",
-      "integrity": "sha512-07ei47p2Xl7Bqbn9H2VYQYirnAFJPwdMuypdozWsSbnmrkgA2e2sZLZdnDNrrsxR4onmIzH/J6KXqKxCuqHtPQ==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-from-markdown": "^1.0.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "packages/remark-plugins/node_modules/remark-rehype": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.0.1.tgz",
@@ -26702,20 +27122,6 @@
         "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
         "mdast-util-to-hast": "^12.0.0",
-        "unified": "^10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/remark-plugins/node_modules/remark-stringify": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.1.tgz",
-      "integrity": "sha512-380vOu9EHqRTDhI9RlPU2EKY1abUDEmxw9fW7pJ/8Jr1izk0UcdnZB30qiDDRYi6pGn5FnVf9Wd2iUeCWTqM7Q==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.0.0",
         "unified": "^10.0.0"
       },
       "funding": {
@@ -26747,23 +27153,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "packages/remark-plugins/node_modules/to-vfile": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.2.tgz",
-      "integrity": "sha512-7WL+coet3qyaYb5vrVrfLtOUHgNv9E1D5SIsyVKmHKcgZefy77WMQRk7FByqGKNInoHOlY6xkTGymo29AwjUKg==",
-      "dependencies": {
-        "is-buffer": "^2.0.0",
-        "vfile": "^5.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "packages/remark-plugins/node_modules/trough": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.0.2.tgz",
       "integrity": "sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -26773,6 +27167,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.0.tgz",
       "integrity": "sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "bail": "^2.0.0",
@@ -26818,18 +27213,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "packages/remark-plugins/node_modules/unist-util-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.0.0.tgz",
-      "integrity": "sha512-kyPbOAlOPZpytdyquF1g6qYpAjkpMpSPtR7TAj4SOQWSJfQ/LN+IFI2oWBvkxzhsPKxiMKZcgpp5ihZLLvNl6g==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "packages/remark-plugins/node_modules/unist-util-position": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.1.tgz",
@@ -26844,6 +27227,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
       "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -26883,6 +27267,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.2.0.tgz",
       "integrity": "sha512-ftCpb6pU8Jrzcqku8zE6N3Gi4/RkDhRwEXSWudzZzA2eEOn/cBpsfk9aulCUR+j1raRSAykYQap9u6j6rhUaCA==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -26898,6 +27283,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
       "integrity": "sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==",
+      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -26905,15 +27291,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "packages/remark-plugins/node_modules/zwitch": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
-      "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "packages/runtime-error-monitoring": {
@@ -29412,7 +29789,7 @@
     "@hashicorp/platform-markdown-utils": {
       "version": "file:packages/markdown-utils",
       "requires": {
-        "@hashicorp/platform-remark-plugins": "^0.1.0",
+        "@hashicorp/platform-remark-plugins": "1.0.0-canary-2022571993",
         "@hashicorp/platform-types": "^0.2.0",
         "@mapbox/rehype-prism": "^0.6.0",
         "@mdx-js/react": "1.6.22",
@@ -29421,6 +29798,42 @@
         "remark-rehype": "^7.0.0"
       },
       "dependencies": {
+        "@hashicorp/platform-remark-plugins": {
+          "version": "1.0.0-canary-2022571993",
+          "resolved": "https://registry.npmjs.org/@hashicorp/platform-remark-plugins/-/platform-remark-plugins-1.0.0-canary-2022571993.tgz",
+          "integrity": "sha512-3pTdLMT9vps9pc5ASdEx8seCz6E9OS8asdu59TcWmQUvk1JSbk7LKQr1ysgGPnYGwkVcM+MCp/tMUWzN4+zHOw==",
+          "requires": {
+            "remark": "^14.0.1",
+            "remark-html": "^15.0.0",
+            "remark-mdx": "^2.0.0-rc.2",
+            "remark-stringify": "^10.0.1",
+            "to-vfile": "^7.2.2",
+            "unist-builder": "^3.0.0",
+            "unist-util-is": "^5.1.1",
+            "unist-util-map": "^3.0.0",
+            "unist-util-visit": "^4.1.0"
+          },
+          "dependencies": {
+            "unist-builder": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.0.tgz",
+              "integrity": "sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==",
+              "requires": {
+                "@types/unist": "^2.0.0"
+              }
+            },
+            "unist-util-visit": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+              "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+              "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.0.0"
+              }
+            }
+          }
+        },
         "@mapbox/rehype-prism": {
           "version": "0.6.0",
           "requires": {
@@ -29478,6 +29891,20 @@
           "integrity": "sha512-uqQ/VbaTdxyu/da6npHAso6hA00cMqhA3a59RziQdOLN2KEIkPykAVy52IcmZEVTuauXO0VtpxkyCey4phtHzQ==",
           "requires": {
             "mdast-util-to-hast": "^9.1.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+          "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+          "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
           }
         }
       }
@@ -29631,18 +30058,14 @@
         "bail": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+          "dev": true
         },
         "ccount": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
           "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
           "dev": true
-        },
-        "character-entities": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
-          "integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ=="
         },
         "character-entities-html4": {
           "version": "2.1.0",
@@ -29653,12 +30076,8 @@
         "character-entities-legacy": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-          "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
-        },
-        "character-reference-invalid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-          "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+          "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+          "dev": true
         },
         "comma-separated-tokens": {
           "version": "2.0.2",
@@ -29706,44 +30125,17 @@
           "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==",
           "dev": true
         },
-        "is-alphabetical": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-          "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
-        },
-        "is-alphanumerical": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-          "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-          "requires": {
-            "is-alphabetical": "^2.0.0",
-            "is-decimal": "^2.0.0"
-          }
-        },
         "is-buffer": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-        },
-        "is-decimal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-          "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
-        },
-        "is-hexadecimal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-          "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
         },
         "is-plain-obj": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
-          "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
-        },
-        "longest-streak": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
-          "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg=="
+          "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+          "dev": true
         },
         "mdast-util-definitions": {
           "version": "5.1.0",
@@ -29779,25 +30171,6 @@
             }
           }
         },
-        "mdast-util-from-markdown": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.1.0.tgz",
-          "integrity": "sha512-Mex7IIeIKRpGYNNywpxTfPhfFBTxBL5IVacPMU6GjYF+EkIvy++19cBgxVFyHVd2JpC/chG2IKGqZLffoo7Q1g==",
-          "requires": {
-            "@types/mdast": "^3.0.0",
-            "@types/unist": "^2.0.0",
-            "mdast-util-to-string": "^3.1.0",
-            "micromark": "^3.0.0",
-            "micromark-util-decode-numeric-character-reference": "^1.0.0",
-            "micromark-util-decode-string": "^1.0.0",
-            "micromark-util-normalize-identifier": "^1.0.0",
-            "micromark-util-symbol": "^1.0.0",
-            "micromark-util-types": "^1.0.0",
-            "parse-entities": "^3.0.0",
-            "unist-util-stringify-position": "^3.0.0",
-            "uvu": "^0.5.0"
-          }
-        },
         "mdast-util-to-hast": {
           "version": "12.0.0",
           "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.0.0.tgz",
@@ -29814,63 +30187,6 @@
             "unist-util-generated": "^2.0.0",
             "unist-util-position": "^4.0.0",
             "unist-util-visit": "^4.0.0"
-          }
-        },
-        "mdast-util-to-markdown": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.4.tgz",
-          "integrity": "sha512-Wive3NvrNS4OY5yYKBADdK1QSlbJUZyZ2ssanITUzNQ7sxMfBANTVjLrAA9BFXshaeG9G77xpOK/z+TTret5Hg==",
-          "requires": {
-            "@types/mdast": "^3.0.0",
-            "@types/unist": "^2.0.0",
-            "longest-streak": "^3.0.0",
-            "mdast-util-to-string": "^3.0.0",
-            "micromark-util-decode-string": "^1.0.0",
-            "unist-util-visit": "^4.0.0",
-            "zwitch": "^2.0.0"
-          }
-        },
-        "mdast-util-to-string": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
-          "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
-        },
-        "micromark": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.7.tgz",
-          "integrity": "sha512-67ipZ2CzQVsDyH1kqNLh7dLwe5QMPJwjFBGppW7JCLByaSc6ZufV0ywPOxt13MIDAzzmj3wctDL6Ov5w0fOHXw==",
-          "requires": {
-            "@types/debug": "^4.0.0",
-            "debug": "^4.0.0",
-            "micromark-core-commonmark": "^1.0.1",
-            "micromark-factory-space": "^1.0.0",
-            "micromark-util-character": "^1.0.0",
-            "micromark-util-chunked": "^1.0.0",
-            "micromark-util-combine-extensions": "^1.0.0",
-            "micromark-util-decode-numeric-character-reference": "^1.0.0",
-            "micromark-util-encode": "^1.0.0",
-            "micromark-util-normalize-identifier": "^1.0.0",
-            "micromark-util-resolve-all": "^1.0.0",
-            "micromark-util-sanitize-uri": "^1.0.0",
-            "micromark-util-subtokenize": "^1.0.0",
-            "micromark-util-symbol": "^1.0.0",
-            "micromark-util-types": "^1.0.1",
-            "parse-entities": "^3.0.0",
-            "uvu": "^0.5.0"
-          }
-        },
-        "parse-entities": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
-          "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "character-entities": "^2.0.0",
-            "character-entities-legacy": "^3.0.0",
-            "character-reference-invalid": "^2.0.0",
-            "is-alphanumerical": "^2.0.0",
-            "is-decimal": "^2.0.0",
-            "is-hexadecimal": "^2.0.0"
           }
         },
         "property-information": {
@@ -29890,36 +30206,6 @@
             "unified": "^10.0.0"
           }
         },
-        "remark": {
-          "version": "14.0.1",
-          "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.1.tgz",
-          "integrity": "sha512-7zLG3u8EUjOGuaAS9gUNJPD2j+SqDqAFHv2g6WMpE5CU9rZ6e3IKDM12KHZ3x+YNje+NMAuN55yx8S5msGSx7Q==",
-          "requires": {
-            "@types/mdast": "^3.0.0",
-            "remark-parse": "^10.0.0",
-            "remark-stringify": "^10.0.0",
-            "unified": "^10.0.0"
-          }
-        },
-        "remark-mdx": {
-          "version": "2.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.0.0-rc.2.tgz",
-          "integrity": "sha512-TMgFSEVx42/YzJWjDY+GKw7CGSbp3XKqBraXPxFS27r8iD9U6zuOZKXH4MoLl9JqiTOmQi0M1zJwT2YhPs32ug==",
-          "requires": {
-            "mdast-util-mdx": "^1.0.0",
-            "micromark-extension-mdxjs": "^1.0.0"
-          }
-        },
-        "remark-parse": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.0.tgz",
-          "integrity": "sha512-07ei47p2Xl7Bqbn9H2VYQYirnAFJPwdMuypdozWsSbnmrkgA2e2sZLZdnDNrrsxR4onmIzH/J6KXqKxCuqHtPQ==",
-          "requires": {
-            "@types/mdast": "^3.0.0",
-            "mdast-util-from-markdown": "^1.0.0",
-            "unified": "^10.0.0"
-          }
-        },
         "remark-rehype": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.0.1.tgz",
@@ -29929,16 +30215,6 @@
             "@types/hast": "^2.0.0",
             "@types/mdast": "^3.0.0",
             "mdast-util-to-hast": "^12.0.0",
-            "unified": "^10.0.0"
-          }
-        },
-        "remark-stringify": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.1.tgz",
-          "integrity": "sha512-380vOu9EHqRTDhI9RlPU2EKY1abUDEmxw9fW7pJ/8Jr1izk0UcdnZB30qiDDRYi6pGn5FnVf9Wd2iUeCWTqM7Q==",
-          "requires": {
-            "@types/mdast": "^3.0.0",
-            "mdast-util-to-markdown": "^1.0.0",
             "unified": "^10.0.0"
           }
         },
@@ -29958,24 +30234,17 @@
             "character-entities-legacy": "^3.0.0"
           }
         },
-        "to-vfile": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.2.tgz",
-          "integrity": "sha512-7WL+coet3qyaYb5vrVrfLtOUHgNv9E1D5SIsyVKmHKcgZefy77WMQRk7FByqGKNInoHOlY6xkTGymo29AwjUKg==",
-          "requires": {
-            "is-buffer": "^2.0.0",
-            "vfile": "^5.1.0"
-          }
-        },
         "trough": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/trough/-/trough-2.0.2.tgz",
-          "integrity": "sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w=="
+          "integrity": "sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w==",
+          "dev": true
         },
         "unified": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.0.tgz",
           "integrity": "sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "bail": "^2.0.0",
@@ -30005,14 +30274,6 @@
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
           "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
         },
-        "unist-util-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.0.0.tgz",
-          "integrity": "sha512-kyPbOAlOPZpytdyquF1g6qYpAjkpMpSPtR7TAj4SOQWSJfQ/LN+IFI2oWBvkxzhsPKxiMKZcgpp5ihZLLvNl6g==",
-          "requires": {
-            "@types/unist": "^2.0.0"
-          }
-        },
         "unist-util-position": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.1.tgz",
@@ -30023,6 +30284,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
           "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0"
           }
@@ -30050,6 +30312,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.2.0.tgz",
           "integrity": "sha512-ftCpb6pU8Jrzcqku8zE6N3Gi4/RkDhRwEXSWudzZzA2eEOn/cBpsfk9aulCUR+j1raRSAykYQap9u6j6rhUaCA==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "is-buffer": "^2.0.0",
@@ -30061,15 +30324,11 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
           "integrity": "sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==",
+          "dev": true,
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-stringify-position": "^3.0.0"
           }
-        },
-        "zwitch": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
-          "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA=="
         }
       }
     },
@@ -30905,16 +31164,6 @@
             "is-alphanumerical": "^2.0.0",
             "is-decimal": "^2.0.0",
             "is-hexadecimal": "^2.0.0"
-          }
-        },
-        "remark-mdx": {
-          "version": "2.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.0.0-rc.2.tgz",
-          "integrity": "sha512-TMgFSEVx42/YzJWjDY+GKw7CGSbp3XKqBraXPxFS27r8iD9U6zuOZKXH4MoLl9JqiTOmQi0M1zJwT2YhPs32ug==",
-          "dev": true,
-          "requires": {
-            "mdast-util-mdx": "^1.0.0",
-            "micromark-extension-mdxjs": "^1.0.0"
           }
         },
         "remark-parse": {
@@ -33918,6 +34167,21 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
+    "decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "requires": {
+        "character-entities": "^2.0.0"
+      },
+      "dependencies": {
+        "character-entities": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
+          "integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ=="
+        }
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0"
@@ -38775,12 +39039,12 @@
       }
     },
     "mdast-util-mdx": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-1.1.0.tgz",
-      "integrity": "sha512-leKb9uG7laXdyFlTleYV4ZEaCpsxeU1LlkkR/xp35pgKrfV1Y0fNCuOw9vaRc2a9YDpH22wd145Wt7UY5yzeZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-2.0.0.tgz",
+      "integrity": "sha512-M09lW0CcBT1VrJUaF/PYxemxxHa7SLDHdSn94Q9FhxjCQfuW7nMAWKWimTmA3OyDMSTH981NN1csW1X+HPSluw==",
       "requires": {
         "mdast-util-mdx-expression": "^1.0.0",
-        "mdast-util-mdx-jsx": "^1.0.0",
+        "mdast-util-mdx-jsx": "^2.0.0",
         "mdast-util-mdxjs-esm": "^1.0.0"
       }
     },
@@ -38793,20 +39057,27 @@
       }
     },
     "mdast-util-mdx-jsx": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-1.1.2.tgz",
-      "integrity": "sha512-1/bDUZvPGNVxiAjrVsehMZTaNomihpbIMoMr8/UcAQ4h7itDFhN93LtO9XzQPlEM+CMueCoRYGQfl7N+5R+8Mg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.0.1.tgz",
+      "integrity": "sha512-oPC7/smPBf7vxnvIYH5y3fPo2lw1rdrswFfSb4i0GTAXRUQv7JUU/t/hbp07dgGdUFTSDOHm5DNamhNg/s2Hrg==",
       "requires": {
         "@types/estree-jsx": "^0.0.1",
+        "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
-        "mdast-util-to-markdown": "^1.0.0",
-        "parse-entities": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "parse-entities": "^4.0.0",
         "stringify-entities": "^4.0.0",
         "unist-util-remove-position": "^4.0.0",
         "unist-util-stringify-position": "^3.0.0",
         "vfile-message": "^3.0.0"
       },
       "dependencies": {
+        "ccount": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+          "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+        },
         "character-entities": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
@@ -38857,9 +39128,9 @@
           "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg=="
         },
         "mdast-util-to-markdown": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.2.4.tgz",
-          "integrity": "sha512-Wive3NvrNS4OY5yYKBADdK1QSlbJUZyZ2ssanITUzNQ7sxMfBANTVjLrAA9BFXshaeG9G77xpOK/z+TTret5Hg==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
+          "integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
           "requires": {
             "@types/mdast": "^3.0.0",
             "@types/unist": "^2.0.0",
@@ -38876,23 +39147,24 @@
           "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
         },
         "parse-entities": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
-          "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
+          "integrity": "sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==",
           "requires": {
             "@types/unist": "^2.0.0",
             "character-entities": "^2.0.0",
             "character-entities-legacy": "^3.0.0",
             "character-reference-invalid": "^2.0.0",
+            "decode-named-character-reference": "^1.0.0",
             "is-alphanumerical": "^2.0.0",
             "is-decimal": "^2.0.0",
             "is-hexadecimal": "^2.0.0"
           }
         },
         "stringify-entities": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.2.tgz",
-          "integrity": "sha512-MTxTVcEkorNtBbNpoFJPEh0kKdM6+QbMjLbaxmvaPMmayOXdr/AIVIIJX7FReUVweRBFJfZepK4A4AKgwuFpMQ==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+          "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
           "requires": {
             "character-entities-html4": "^2.0.0",
             "character-entities-legacy": "^3.0.0"
@@ -38903,19 +39175,10 @@
           "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
           "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
         },
-        "unist-util-remove-position": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.1.tgz",
-          "integrity": "sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==",
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-visit": "^4.0.0"
-          }
-        },
         "unist-util-stringify-position": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
-          "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+          "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
           "requires": {
             "@types/unist": "^2.0.0"
           }
@@ -38940,9 +39203,9 @@
           }
         },
         "vfile-message": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
-          "integrity": "sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+          "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-stringify-position": "^3.0.0"
@@ -41929,6 +42192,139 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
+    "remark": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
+      "integrity": "sha512-A3ARm2V4BgiRXaUo5K0dRvJ1lbogrbXnhkJRmD0yw092/Yl0kOCZt1k9ZeElEwkZsWGsMumz6qL5MfNJH9nOBA==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-stringify": "^10.0.0",
+        "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+          "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+        },
+        "mdast-util-from-markdown": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
+          "integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "mdast-util-to-string": "^3.1.0",
+            "micromark": "^3.0.0",
+            "micromark-util-decode-numeric-character-reference": "^1.0.0",
+            "micromark-util-decode-string": "^1.0.0",
+            "micromark-util-normalize-identifier": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "uvu": "^0.5.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+          "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
+        },
+        "micromark": {
+          "version": "3.0.10",
+          "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.10.tgz",
+          "integrity": "sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==",
+          "requires": {
+            "@types/debug": "^4.0.0",
+            "debug": "^4.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "micromark-core-commonmark": "^1.0.1",
+            "micromark-factory-space": "^1.0.0",
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-chunked": "^1.0.0",
+            "micromark-util-combine-extensions": "^1.0.0",
+            "micromark-util-decode-numeric-character-reference": "^1.0.0",
+            "micromark-util-encode": "^1.0.0",
+            "micromark-util-normalize-identifier": "^1.0.0",
+            "micromark-util-resolve-all": "^1.0.0",
+            "micromark-util-sanitize-uri": "^1.0.0",
+            "micromark-util-subtokenize": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.1",
+            "uvu": "^0.5.0"
+          }
+        },
+        "remark-parse": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
+          "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "mdast-util-from-markdown": "^1.0.0",
+            "unified": "^10.0.0"
+          }
+        },
+        "trough": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+          "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+          "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+          "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+          "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        }
+      }
+    },
     "remark-html": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-15.0.0.tgz",
@@ -42177,10 +42573,146 @@
         "micromark-extension-math": "^0.1.0"
       }
     },
+    "remark-mdx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.1.1.tgz",
+      "integrity": "sha512-0wXdEITnFyjLquN3VvACNLzbGzWM5ujzTvfgOkONBZgSFJ7ezLLDaTWqf6H9eUgVITEP8asp6LJ0W/X090dXBg==",
+      "requires": {
+        "mdast-util-mdx": "^2.0.0",
+        "micromark-extension-mdxjs": "^1.0.0"
+      }
+    },
     "remark-parse": {
       "version": "9.0.0",
       "requires": {
         "mdast-util-from-markdown": "^0.8.0"
+      }
+    },
+    "remark-stringify": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.2.tgz",
+      "integrity": "sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+          "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+        },
+        "longest-streak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
+          "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg=="
+        },
+        "mdast-util-to-markdown": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
+          "integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "longest-streak": "^3.0.0",
+            "mdast-util-to-string": "^3.0.0",
+            "micromark-util-decode-string": "^1.0.0",
+            "unist-util-visit": "^4.0.0",
+            "zwitch": "^2.0.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+          "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
+        },
+        "trough": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+          "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+          "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+          "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+          "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+          "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+          "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+          "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        },
+        "zwitch": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
+          "integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA=="
+        }
       }
     },
     "remove-trailing-separator": {
@@ -44548,6 +45080,50 @@
         "is-number": "^7.0.0"
       }
     },
+    "to-vfile": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.3.tgz",
+      "integrity": "sha512-QO0A9aE6Z/YkmQadJ0syxpmNXtcQiu0qAtCKYKD5cS3EfgfFTAXfgLX6AOaBrSfWSek5nfsMf3gBZ9KGVFcLuw==",
+      "requires": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^5.1.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+          "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+          "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+          "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        }
+      }
+    },
     "toidentifier": {
       "version": "1.0.0"
     },
@@ -44878,6 +45454,14 @@
     "unist-util-is": {
       "version": "4.1.0"
     },
+    "unist-util-map": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-3.1.1.tgz",
+      "integrity": "sha512-n36sjBn4ibPtAzrFweyT4FOcCI/UdzboaEcsZvwoAyD/gVw5B3OLlMBySePMO6r+uzjxQEyRll2akfVaT4SHhw==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
     "unist-util-position": {
       "version": "3.1.0"
     },
@@ -44887,6 +45471,41 @@
       "integrity": "sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==",
       "requires": {
         "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-remove-position": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.1.tgz",
+      "integrity": "sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+          "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+        },
+        "unist-util-visit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+          "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+          "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        }
       }
     },
     "unist-util-stringify-position": {

--- a/packages/markdown-utils/index.ts
+++ b/packages/markdown-utils/index.ts
@@ -1,4 +1,4 @@
-import { allPlugins } from '@hashicorp/remark-plugins'
+import { allPlugins } from '@hashicorp/platform-remark-plugins'
 import highlight from '@mapbox/rehype-prism'
 import { Pluggable } from 'unified'
 import remarkMath from 'remark-math'

--- a/packages/markdown-utils/index.ts
+++ b/packages/markdown-utils/index.ts
@@ -1,37 +1,9 @@
-import {
-  anchorLinks,
-  includeMarkdown,
-  paragraphCustomAlerts,
-  typography,
-} from '@hashicorp/platform-remark-plugins'
+import allPlugins from '@hashicorp/platform-remark-plugins/all'
 import highlight from '@mapbox/rehype-prism'
 import { Pluggable } from 'unified'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import rehypeSurfaceCodeNewlines from '@hashicorp/platform-code-highlighting/rehype-surface-code-newlines'
-
-/**
- * TODO
- *
- * allPlugins was previously present as part of the remark-plugins, but has
- * since been removed and is not present in platform-remark-plugins.
- *
- * One path forward might be to rely on consumers providing remarkPlugins,
- * rather than providing a set of defaults that can only be _extended_
- * with addRemarkPlugins.
- */
-function allPlugins({
-  anchorLinks: anchorLinksOptions,
-  typography: typographyOptions,
-  includeMarkdown: includeMarkdownOptions,
-}: $TSFixMe) {
-  return [
-    [includeMarkdown, includeMarkdownOptions],
-    [anchorLinks, anchorLinksOptions],
-    paragraphCustomAlerts,
-    [typography, typographyOptions],
-  ]
-}
 
 interface MarkdownDefaults {
   remarkPlugins: Pluggable[]

--- a/packages/markdown-utils/index.ts
+++ b/packages/markdown-utils/index.ts
@@ -1,9 +1,27 @@
-import { allPlugins } from '@hashicorp/platform-remark-plugins'
+import {
+  anchorLinks,
+  includeMarkdown,
+  paragraphCustomAlerts,
+  typography,
+} from '@hashicorp/platform-remark-plugins'
 import highlight from '@mapbox/rehype-prism'
 import { Pluggable } from 'unified'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import rehypeSurfaceCodeNewlines from '@hashicorp/platform-code-highlighting/rehype-surface-code-newlines'
+
+function allPlugins({
+  anchorLinks: anchorLinksOptions,
+  typography: typographyOptions,
+  includeMarkdown: includeMarkdownOptions,
+}: $TSFixMe) {
+  return [
+    [includeMarkdown, includeMarkdownOptions],
+    [anchorLinks, anchorLinksOptions],
+    paragraphCustomAlerts,
+    [typography, typographyOptions],
+  ]
+}
 
 interface MarkdownDefaults {
   remarkPlugins: Pluggable[]

--- a/packages/markdown-utils/index.ts
+++ b/packages/markdown-utils/index.ts
@@ -10,6 +10,16 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import rehypeSurfaceCodeNewlines from '@hashicorp/platform-code-highlighting/rehype-surface-code-newlines'
 
+/**
+ * TODO
+ *
+ * allPlugins was previously present as part of the remark-plugins, but has
+ * since been removed and is not present in platform-remark-plugins.
+ *
+ * One path forward might be to rely on consumers providing remarkPlugins,
+ * rather than providing a set of defaults that can only be _extended_
+ * with addRemarkPlugins.
+ */
 function allPlugins({
   anchorLinks: anchorLinksOptions,
   typography: typographyOptions,

--- a/packages/markdown-utils/package.json
+++ b/packages/markdown-utils/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.1",
   "author": "HashiCorp",
   "dependencies": {
-    "@hashicorp/platform-remark-plugins": "1.0.0-canary-2022571993",
+    "@hashicorp/platform-remark-plugins": "^1.0.0-canary-2022571993",
     "@hashicorp/platform-types": "^0.2.0",
     "@mapbox/rehype-prism": "^0.6.0",
     "@mdx-js/react": "1.6.22",

--- a/packages/markdown-utils/package.json
+++ b/packages/markdown-utils/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.1",
   "author": "HashiCorp",
   "dependencies": {
-    "@hashicorp/platform-remark-plugins": "^0.1.0",
+    "@hashicorp/platform-remark-plugins": "1.0.0-canary-2022571993",
     "@hashicorp/platform-types": "^0.2.0",
     "@mapbox/rehype-prism": "^0.6.0",
     "@mdx-js/react": "1.6.22",

--- a/packages/markdown-utils/package.json
+++ b/packages/markdown-utils/package.json
@@ -4,8 +4,8 @@
   "version": "0.2.1",
   "author": "HashiCorp",
   "dependencies": {
+    "@hashicorp/platform-remark-plugins": "^0.1.0",
     "@hashicorp/platform-types": "^0.2.0",
-    "@hashicorp/remark-plugins": "^3.3.1",
     "@mapbox/rehype-prism": "^0.6.0",
     "@mdx-js/react": "1.6.22",
     "rehype-katex": "^5.0.0",

--- a/packages/remark-plugins/index.js
+++ b/packages/remark-plugins/index.js
@@ -1,4 +1,18 @@
-export { default as anchorLinks } from './plugins/anchor-links/index.js'
-export { default as paragraphCustomAlerts } from './plugins/paragraph-custom-alerts/index.js'
-export { default as typography } from './plugins/typography/index.js'
-export { default as includeMarkdown } from './plugins/include-markdown/index.js'
+import anchorLinks from './plugins/anchor-links/index.js'
+import paragraphCustomAlerts from './plugins/paragraph-custom-alerts/index.js'
+import typography from './plugins/typography/index.js'
+import includeMarkdown from './plugins/include-markdown/index.js'
+
+const allPlugins = ({
+  anchorLinks: anchorLinksOptions,
+  typography: typographyOptions,
+  includeMarkdown: includeMarkdownOptions,
+} = {}) => [
+  [includeMarkdown, includeMarkdownOptions],
+  [anchorLinks, anchorLinksOptions],
+  paragraphCustomAlerts,
+  [typography, typographyOptions],
+]
+
+export { anchorLinks, paragraphCustomAlerts, typography, includeMarkdown }
+export default allPlugins

--- a/packages/remark-plugins/index.js
+++ b/packages/remark-plugins/index.js
@@ -1,18 +1,4 @@
-import anchorLinks from './plugins/anchor-links/index.js'
-import paragraphCustomAlerts from './plugins/paragraph-custom-alerts/index.js'
-import typography from './plugins/typography/index.js'
-import includeMarkdown from './plugins/include-markdown/index.js'
-
-const allPlugins = ({
-  anchorLinks: anchorLinksOptions,
-  typography: typographyOptions,
-  includeMarkdown: includeMarkdownOptions,
-} = {}) => [
-  [includeMarkdown, includeMarkdownOptions],
-  [anchorLinks, anchorLinksOptions],
-  paragraphCustomAlerts,
-  [typography, typographyOptions],
-]
-
-export { anchorLinks, paragraphCustomAlerts, typography, includeMarkdown }
-export default allPlugins
+export { default as anchorLinks } from './plugins/anchor-links/index.js'
+export { default as paragraphCustomAlerts } from './plugins/paragraph-custom-alerts/index.js'
+export { default as typography } from './plugins/typography/index.js'
+export { default as includeMarkdown } from './plugins/include-markdown/index.js'

--- a/packages/remark-plugins/plugins/anchor-links/index.js
+++ b/packages/remark-plugins/plugins/anchor-links/index.js
@@ -56,6 +56,7 @@ function processHeading(node, compatibilitySlug, links, headings) {
     .substring(level + 1)
     .replace(/<\/?[^>]*>/g, '') // Strip html
     .replace(/\(\(#.*?\)\)/g, '') // Strip anchor link aliases
+    .replace(/»/g, '') // Safeguard against double-running this plugin
     .replace(/\s+/g, ' ') // Collapse whitespace
     .trim()
 

--- a/packages/remark-plugins/plugins/anchor-links/index.js
+++ b/packages/remark-plugins/plugins/anchor-links/index.js
@@ -67,8 +67,14 @@ function processHeading(node, compatibilitySlug, links, headings) {
     hProperties: { ...node.data?.hProperties, id: slug },
   }
 
-  // handle anchor link aliases
-  const aliases = processAlias(node, 1)
+  /**
+   * Handle anchor link aliases
+   *
+   * Note: depends on children of heading element! Expects first child,
+   * at index 0, to be the text element. As well, aliases must be attached
+   * to separate __target-h elements.
+   */
+  const aliases = processAlias(node, 0)
   if (aliases.length) node.children.unshift(...aliasesToNodes(aliases, 'h'))
 
   // if the compatibilitySlug option is present, we generate it and add it

--- a/packages/remark-plugins/plugins/anchor-links/index.js
+++ b/packages/remark-plugins/plugins/anchor-links/index.js
@@ -59,19 +59,19 @@ function processHeading(node, compatibilitySlug, links, headings) {
     .replace(/\s+/g, ' ') // Collapse whitespace
     .trim()
 
-  // generate the slug and add a target element to the headline
+  // generate the slug and use it as the headline's id property
   const slug = generateSlug(text, links)
-  node.children.unshift({
-    type: 'html',
-    value: `<a class="__target-h" id="${slug}" aria-hidden="true"></a>`,
-  })
+  node.data = {
+    ...node.data,
+    hProperties: { ...node.data?.hProperties, id: slug },
+  }
 
   // handle anchor link aliases
   const aliases = processAlias(node, 1)
   if (aliases.length) node.children.unshift(...aliasesToNodes(aliases, 'h'))
 
   // if the compatibilitySlug option is present, we generate it and add it
-  // if it doesn't already match the existing slug
+  // as separate target elements if it doesn't already match the existing slug
   let slug2
   if (compatibilitySlug) {
     slug2 = compatibilitySlug(text)

--- a/packages/remark-plugins/plugins/anchor-links/index.test.js
+++ b/packages/remark-plugins/plugins/anchor-links/index.test.js
@@ -8,9 +8,8 @@ describe('anchor-links', () => {
       const headings = []
       expect(execute('# hello world', { headings })).toMatch(
         [
-          '<h1>',
+          '<h1 id="hello-world">',
           '<a class="__permalink-h" href="#hello-world" aria-label="hello world permalink">»</a>',
-          '<a class="__target-h" id="hello-world" aria-hidden="true"></a>',
           'hello world',
           '</h1>',
         ].join('')
@@ -687,7 +686,7 @@ function execute(input, options = {}) {
 }
 
 function expectedHeadingResult({ slug, compatSlugs, aria, text, level }) {
-  const res = [`<h${level || '1'}>`]
+  const res = [`<h${level || '1'} id="${slug}">`]
   res.push(
     `<a class="__permalink-h" href="#${
       compatSlugs && compatSlugs.length ? compatSlugs[0] : slug
@@ -701,7 +700,6 @@ function expectedHeadingResult({ slug, compatSlugs, aria, text, level }) {
       )
     )
   }
-  res.push(`<a class="__target-h" id="${slug}" aria-hidden="true"></a>`)
   res.push(text || slug)
   res.push(`</h${level || '1'}>`)
   return res.join('')

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -6,6 +6,7 @@ declare module 'next-transpile-modules'
 
 declare module '@hashicorp/remark-plugins'
 declare module '@hashicorp/platform-remark-plugins'
+declare module '@hashicorp/platform-remark-plugins/all'
 declare module '@hashicorp/react-consent-manager'
 
 declare module 'rivet-graphql'

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -5,6 +5,7 @@ declare module 'next-optimized-images'
 declare module 'next-transpile-modules'
 
 declare module '@hashicorp/remark-plugins'
+declare module '@hashicorp/platform-remark-plugins'
 declare module '@hashicorp/react-consent-manager'
 
 declare module 'rivet-graphql'


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202114367927919/1202384957391166/f)

---

## Description 

This PR modifies the `anchor-links` remark plugin. It removes the extra `__target-h` element, and instead places the target `id` directly on the `heading` element.

I've proven this PR out in `dev-portal`:
- https://github.com/hashicorp/dev-portal/pull/559

Note that additional `__target-h` elements may still be present if "aliases" are used.

## Summary of changes

- `@hashicorp/platform-remark-plugins` - in `anchor-links`, moves `id` to `h{n}` element
- `@hashicorp/platform-markdown-utils` - updates to use `@hashicorp/platform-remark-plugins`
    - Was previously using `@hashicorp/remark-plugins`
    - May need to bump again in subsequent PR to get the `anchor-links` fix in
- `@hashicorp/platform-types` - adds `@hashicorp/platform-remark-plugins`
    - Seems necessary for same reason `@hashicorp/remark-plugins` was - not in TypeScript yet

## PR Checklist 🚀

- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
