### PR TITLE
feat: disable esmodules for framer-motion

### DIFF
--- a/.changeset/cuddly-zebras-beam.md
+++ b/.changeset/cuddly-zebras-beam.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-nextjs-plugin': minor
+---
+
+Disable ES modules for framer-motion

--- a/packages/nextjs-plugin/src/index.ts
+++ b/packages/nextjs-plugin/src/index.ts
@@ -4,6 +4,7 @@ import withOptimizedImages from '@hashicorp/next-optimized-images'
 import withTMBase from 'next-transpile-modules'
 import { NextConfig } from 'next/dist/next-server/server/config'
 import withGraphqlBasic from './plugins/with-graphql-basic'
+import withFramerMotionEsmodulesDisabled from './plugins/with-framer-motion-esmodules-disabled'
 import { getHashicorpPackages } from './get-hashicorp-packages'
 
 const debugLog = util.debuglog('nextjs-scripts')
@@ -33,6 +34,7 @@ function withHashicorp({
     const chain = [
       withBundleAnalyzer({ enabled: process.env.ANALYZE === 'true' }),
       withGraphqlBasic(),
+      withFramerMotionEsmodulesDisabled()
     ]
 
     // If nextOptimizedImages is true, add the plugin and set the necessary config value

--- a/packages/nextjs-plugin/src/plugins/with-framer-motion-esmodules-disabled.js
+++ b/packages/nextjs-plugin/src/plugins/with-framer-motion-esmodules-disabled.js
@@ -1,0 +1,23 @@
+// Very simple plugin that disables resolution of the `exports` field
+// for framer-motion
+
+module.exports = function withFramerMotionEsmodulesDisabled() {
+  return function withFramerMotionEsmodulesDisabledInternal(nextConfig = {}) {
+    return Object.assign({}, nextConfig, {
+      webpack(config, options) {
+        config.module.rules.push({
+          test: /framer-motion/,
+          resolve: {
+            exportsFields: [],
+          },
+        })
+
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(config, options)
+        }
+
+        return config
+      },
+    })
+  }
+}


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

This PR disables resolution of the `exports` field for `framer-motion` in order to support importing arbitrary file paths from the package.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
