### PR TITLE
feat: allow imports from framer-motion across exports boundary

### DIFF
--- a/.changeset/cool-boats-taste.md
+++ b/.changeset/cool-boats-taste.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-types': minor
+---
+
+Allow imports from framer-motion across exports boundary

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -7,6 +7,9 @@ declare module 'next-transpile-modules'
 declare module '@hashicorp/remark-plugins'
 declare module '@hashicorp/react-consent-manager'
 
+declare module 'framer-motion/dist/es/motion/features/layout'
+declare module 'framer-motion/dist/es/projection/node/HTMLProjectionNode'
+
 declare module 'rivet-graphql'
 declare module '*.graphql'
 


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

Adds the module declarations to our platform types package that allow for the importing of modules that aren't exported by `framer-motion`'s `exports` configuration.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
