### PR TITLE
fix: add support for motion-config paths from react-components

### DIFF
--- a/.changeset/clever-snakes-yawn.md
+++ b/.changeset/clever-snakes-yawn.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-nextjs-plugin': minor
+---
+
+Handle motion-config paths from react-components

--- a/packages/nextjs-plugin/src/plugins/with-framer-motion-esmodules-disabled.js
+++ b/packages/nextjs-plugin/src/plugins/with-framer-motion-esmodules-disabled.js
@@ -6,7 +6,7 @@ module.exports = function withFramerMotionEsmodulesDisabled() {
     return Object.assign({}, nextConfig, {
       webpack(config, options) {
         config.module.rules.push({
-          test: /framer-motion|react-motion-config/,
+          test: /framer-motion|motion-config/,
           resolve: {
             exportsFields: [],
           },


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

This PR updates the test for framer-motion and react-motion-config to account for the fact that motion-config paths in `react-components` doesn't use the `react-` prefix.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
