### PR TITLE
Create `useErrorPageAnalytics` hook

### DIFF
--- a/.changeset/nasty-schools-peel.md
+++ b/.changeset/nasty-schools-peel.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-analytics': patch
+---
+
+Add useErrorPageAnalytics hook

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -1,4 +1,5 @@
 import usePageviewAnalytics from './use-page-view-analytics'
+import useErrorPageAnalytics from './use-error-page-analytics'
 import { getProductIntentFromURL } from './get-product-intent-from-url'
 import {
   initializeUTMParamsCapture,
@@ -9,6 +10,7 @@ import { addCloudLinkHandler } from './add-cloud-link-handler'
 export default usePageviewAnalytics
 export {
   usePageviewAnalytics,
+  useErrorPageAnalytics,
   getProductIntentFromURL,
   initializeUTMParamsCapture,
   getUTMParamsCaptureState,

--- a/packages/analytics/use-error-page-analytics/index.tsx
+++ b/packages/analytics/use-error-page-analytics/index.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+
+/**
+ * Given an error category to record,
+ * make a call to window.analytics.track on mount and
+ * when the provided statusCode changes, in order to record the
+ * the specified error at the current window.location.href.
+ *
+ * Relies on window.analytics.track() being a valid function
+ * which can be called as window.analytics.track(href, { category, label }).
+ */
+export default function useErrorPageAnalytics(
+  /** The type of error. Used to send a "{statusCode} Response"
+   * category value to window.analytics.track, if that's possible. */
+  statusCode: number
+): void {
+  useEffect(() => {
+    if (
+      typeof window !== 'undefined' &&
+      typeof window?.analytics?.track === 'function' &&
+      typeof window?.document?.referrer === 'string' &&
+      typeof window?.location?.href === 'string'
+    )
+      window.analytics.track('Error Page Loaded', {
+        http_status_code: statusCode,
+        label: window?.location?.href,
+        referrer: window?.document?.referrer || 'No Referrer',
+      })
+  }, [statusCode])
+}

--- a/packages/analytics/use-error-page-analytics/index.tsx
+++ b/packages/analytics/use-error-page-analytics/index.tsx
@@ -7,18 +7,16 @@ import { useEffect } from 'react'
  * the specified error at the current window.location.href.
  *
  * Relies on window.analytics.track() being a valid function
- * which can be called as window.analytics.track(href, { category, label }).
+ * which can be called as window.analytics.track('Error Page Loaded', { http_status_code, label, referrer }).
  */
 export default function useErrorPageAnalytics(
-  /** The type of error. Used to send a "{statusCode} Response"
-   * category value to window.analytics.track, if that's possible. */
+  /** The HTTP status code to send with the track event under `http_status_code` */
   statusCode: number
 ): void {
   useEffect(() => {
     if (
       typeof window !== 'undefined' &&
       typeof window?.analytics?.track === 'function' &&
-      typeof window?.document?.referrer === 'string' &&
       typeof window?.location?.href === 'string'
     )
       window.analytics.track('Error Page Loaded', {


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202791227659279/1202865459293217/f)

---

## Description
It was recently discovered that, across our various web properties, we make the following call:

`window.analytics.track(window.location.href, { ... } )`

The first parameter of the `track` method is used downstream in our various data warehouses to create a new table. Since we're using `window.location.href`, we're creating a table for _every_ URL that 404s. This is not ideal for analytics.

## Solution
This PR creates a new `useErrorPageAnalytics` hook for pushing 404-related data to Segment. It is a near-copy of the [useErrorPageAnalytics hook in React Components](https://github.com/hashicorp/react-components/blob/main/packages/error-view/use-error-page-analytics.ts). The key difference is that we're adding the following to the payload:

```
label: window?.location?.href,
referrer: window?.document?.referrer || 'No Referrer',
```

After pairing with Alex, we decided that it made more sense for this hook to live in `web-platform-packages` (versus `react-components`).  If time allows, it would be ideal to deprecate the version in `react-components` and replace all of its references with this newly created hook.

## PR Checklist 🚀

- [x] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
