### PR TITLE
Use `useErrorPageAnalytics` hook on 404 page

### DIFF
--- a/.changeset/eighty-starfishes-occur.md
+++ b/.changeset/eighty-starfishes-occur.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-cli': minor
+---
+
+Uses useErrorPageAnalytics hook for 404 tracking

--- a/packages/cli/generators/website/templates/pages/404.js
+++ b/packages/cli/generators/website/templates/pages/404.js
@@ -1,19 +1,8 @@
 import Link from 'next/link'
-import { useEffect } from 'react'
+import { useErrorPageAnalytics } from 'packages/analytics'
 
 export default function NotFound() {
-  useEffect(() => {
-    if (
-      typeof window !== 'undefined' &&
-      typeof window?.analytics?.track === 'function' &&
-      typeof window?.document?.referrer === 'string' &&
-      typeof window?.location?.href === 'string'
-    )
-      window.analytics.track(window.location.href, {
-        category: '404 Response',
-        label: window.document.referrer || 'No Referrer',
-      })
-  }, [])
+  useErrorPageAnalytics(404)
 
   return (
     <div id="p-404">


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202791227659279/1202865459293217/f)

---

## Description
It was recently discovered that, across our various web properties, we make the following call:

`window.analytics.track(window.location.href, { ... } )`

The first parameter of the `track` method is used downstream in our various data warehouses to create a new table. Since we're using `window.location.href`, we're creating a table for _every_ URL that 404s. This is not ideal for analytics.

## Solution
This PR leverages the new `useErrorPageAnalytics` hook (see [this PR](https://github.com/hashicorp/web-platform-packages/pull/86)) for pushing 404-related data to Segment. This PR replaces the `window.analytics.track` call on the 404 page with said hook.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
