### PR TITLE
feat(add-cloud-link-handler): ensure handler is only added once

### DIFF
--- a/packages/analytics/add-cloud-link-handler/index.ts
+++ b/packages/analytics/add-cloud-link-handler/index.ts
@@ -10,10 +10,14 @@ const containsDestination = (str: string): boolean =>
     return str.indexOf(destination) >= 0
   })
 
+// Track if we've setup this handler already to prevent registering the handler
+// multiple times.
+let hasHandler = false
+
 export function addCloudLinkHandler(
   callback?: (destinationUrl: string) => void
 ) {
-  if (typeof window === 'undefined') return
+  if (typeof window === 'undefined' || hasHandler) return
 
   window.addEventListener('click', (event) => {
     const linkElement = (event.target as HTMLElement).closest('a')
@@ -47,4 +51,6 @@ export function addCloudLinkHandler(
       }
     }
   })
+
+  hasHandler = true
 }


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

This PR ensures that the `click` handler in `add-cloud-link-handler` is only added once. This prevents a situation where the handler is added multiple times, leading to multiple analytics tracking calls.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
