### PR TITLE
feat(getProductIntentFromURL): handle HCP in URLs

### DIFF
--- a/.changeset/nine-buckets-act.md
+++ b/.changeset/nine-buckets-act.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-analytics': minor
+---
+
+add hcp product intent check

--- a/packages/analytics/get-product-intent-from-url/index.test.js
+++ b/packages/analytics/get-product-intent-from-url/index.test.js
@@ -50,4 +50,15 @@ describe('getProductIntentFromURL', () => {
       )
     ).toBe('packer')
   })
+
+  it('handles HCP urls', () => {
+    expect(getProductIntentFromURL('https://developer.hashicorp.com/hcp')).toBe(
+      'hcp'
+    )
+    expect(
+      getProductIntentFromURL(
+        'https://developer.hashicorp.com/hcp/docs/terraform'
+      )
+    ).toBe('terraform')
+  })
 })

--- a/packages/analytics/get-product-intent-from-url/index.ts
+++ b/packages/analytics/get-product-intent-from-url/index.ts
@@ -12,7 +12,7 @@ const products = [
 type Product = typeof products[number]
 
 /**
- * Based on a URL, return the first instance of a product name within
+ * Based on a URL, return the first instance of a product name or HCP within
  * a URL else return null.
  * @example
  * // returns consul

--- a/packages/analytics/get-product-intent-from-url/index.ts
+++ b/packages/analytics/get-product-intent-from-url/index.ts
@@ -9,7 +9,7 @@ const products = [
   'vagrant',
 ] as const
 
-type Product = typeof products[number] | 'hcp'
+type Product = typeof products[number]
 
 /**
  * Based on a URL, return the first instance of a product name within
@@ -23,7 +23,9 @@ type Product = typeof products[number] | 'hcp'
  * @param {string} [url] defaults to window object if no URL is provided
  * @returns {string | null} A product name or null
  */
-export const getProductIntentFromURL = (url?: string): Product | null => {
+export const getProductIntentFromURL = (
+  url?: string
+): Product | 'hcp' | null => {
   if (!url && typeof window === 'undefined') {
     return null
   }

--- a/packages/analytics/get-product-intent-from-url/index.ts
+++ b/packages/analytics/get-product-intent-from-url/index.ts
@@ -9,7 +9,7 @@ const products = [
   'vagrant',
 ] as const
 
-type Product = typeof products[number]
+type Product = typeof products[number] | 'hcp'
 
 /**
  * Based on a URL, return the first instance of a product name within
@@ -41,5 +41,13 @@ export const getProductIntentFromURL = (url?: string): Product | null => {
     .filter(([_, index]) => index > -1)
     .sort((a, b) => a[1] - b[1])
 
-  return productIntent.length ? productIntent[0][0] : null
+  if (productIntent.length) {
+    return productIntent[0][0]
+  }
+
+  if (fromUrl.includes('hcp')) {
+    return 'hcp'
+  }
+
+  return null
 }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202578820078349/1203095277649754/f)

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->

Adds support for HCP returned as product intent.

If a product is in the URL, still return the product else if hcp is in the url return hcp.

```
https://developer.hashicorp.com => null
https://developer.hashicorp.com/hcp => hcp
https://developer.hashicorp.com/hcp/docs/terraform => terraform
```

## PR Checklist 🚀

- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
