### PR TITLE
feat(analytics): `addGlobalLinkHandler`

### DIFF
--- a/.changeset/beige-mails-ring.md
+++ b/.changeset/beige-mails-ring.md
@@ -2,4 +2,4 @@
 '@hashicorp/platform-analytics': minor
 ---
 
-add addAnonymousIdHandler
+add addGlobalLinkHandler

--- a/.changeset/beige-mails-ring.md
+++ b/.changeset/beige-mails-ring.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-analytics': minor
+---
+
+add addAnonymousIdHandler

--- a/packages/analytics/add-anonymous-id-handler/index.ts
+++ b/packages/analytics/add-anonymous-id-handler/index.ts
@@ -18,36 +18,36 @@ export function addAnonymousIdHandler() {
 
   window.addEventListener('click', (event) => {
     const linkElement = (event.target as HTMLElement).closest('a')
-    if (linkElement && containsDestination(linkElement.href)) {
+    if (
+      linkElement &&
+      containsDestination(linkElement.href) &&
+      isValidUrl(linkElement.href)
+    ) {
       event.preventDefault()
-      try {
-        const url = new URL(linkElement.href)
-        const ajs_uid = safeGetSegmentId()
-        if (ajs_uid) {
-          url.searchParams.append('ajs_uid', ajs_uid)
-        }
-        if (
-          linkElement.getAttribute('target') === '_blank' ||
-          event.ctrlKey ||
-          event.metaKey
-        ) {
-          window.open(url.href, '_blank')
-        } else {
-          location.href = url.href
-        }
-      } catch {
-        if (
-          linkElement.getAttribute('target') === '_blank' ||
-          event.ctrlKey ||
-          event.metaKey
-        ) {
-          window.open(linkElement.href, '_blank')
-        } else {
-          location.href = linkElement.href
-        }
+      const url = new URL(linkElement.href)
+      const ajs_uid = safeGetSegmentId()
+      if (ajs_uid) {
+        url.searchParams.append('ajs_uid', ajs_uid)
+      }
+      if (
+        linkElement.getAttribute('target') === '_blank' ||
+        event.ctrlKey ||
+        event.metaKey
+      ) {
+        window.open(url.href, '_blank')
+      } else {
+        location.href = url.href
       }
     }
   })
+}
+
+function isValidUrl(url: string): boolean {
+  try {
+    return Boolean(new URL(url))
+  } catch (e) {
+    return false
+  }
 }
 
 function safeGetSegmentId(): string | null {

--- a/packages/analytics/add-anonymous-id-handler/index.ts
+++ b/packages/analytics/add-anonymous-id-handler/index.ts
@@ -1,0 +1,64 @@
+const destinations: string[] = [
+  'hashicorp.com',
+  'terraform.io',
+  'consul.io',
+  'vaultproject.io',
+  'waypointproject.io',
+  'packer.io',
+  'boundaryproject.io',
+]
+
+const containsDestination = (str: string): boolean =>
+  destinations.some(function (destination) {
+    return str.indexOf(destination) >= 0
+  })
+
+export function addAnonymousIdHandler() {
+  if (typeof window === 'undefined') return
+
+  window.addEventListener('click', (event) => {
+    const linkElement = (event.target as HTMLElement).closest('a')
+    if (linkElement && containsDestination(linkElement.href)) {
+      event.preventDefault()
+      try {
+        const url = new URL(linkElement.href)
+        const ajs_uid = safeGetSegmentId()
+        if (ajs_uid) {
+          url.searchParams.append('ajs_uid', ajs_uid)
+        }
+        if (
+          linkElement.getAttribute('target') === '_blank' ||
+          event.ctrlKey ||
+          event.metaKey
+        ) {
+          window.open(url.href, '_blank')
+        } else {
+          location.href = url.href
+        }
+      } catch {
+        if (
+          linkElement.getAttribute('target') === '_blank' ||
+          event.ctrlKey ||
+          event.metaKey
+        ) {
+          window.open(linkElement.href, '_blank')
+        } else {
+          location.href = linkElement.href
+        }
+      }
+    }
+  })
+}
+
+function safeGetSegmentId(): string | null {
+  if (
+    typeof window !== undefined &&
+    window.analytics &&
+    window.analytics.user &&
+    typeof window.analytics.user === 'function'
+  ) {
+    return window.analytics.user().anonymousId()
+  } else {
+    return null
+  }
+}

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -31,8 +31,9 @@ export function addGlobalLinkHandler(
 
   window.addEventListener('click', (event) => {
     const linkElement = (event.target as HTMLElement).closest('a')
+
     if (linkElement && containsDestination(linkElement.href)) {
-      const segmentAnonymousId = safeGetSegmentId()
+      const segmentAnonymousId = getSafeSegmentId()
       const productIntent = getProductIntentFromURL()
       const utmParams = getUTMParamsCaptureState()
 
@@ -41,11 +42,11 @@ export function addGlobalLinkHandler(
       const url = new URL(linkElement.href)
 
       if (segmentAnonymousId) {
-        url.searchParams.append('ajs_uid', segmentAnonymousId)
+        url.searchParams.set('ajs_uid', segmentAnonymousId)
       }
 
       if (productIntent) {
-        url.searchParams.append('product_intent', productIntent)
+        url.searchParams.set('product_intent', productIntent)
       }
 
       if (Object.keys(utmParams).length > 0) {
@@ -71,7 +72,7 @@ export function addGlobalLinkHandler(
   hasHandler = true
 }
 
-function safeGetSegmentId(): string | null {
+function getSafeSegmentId(): string | null {
   if (
     typeof window !== undefined &&
     window.analytics &&

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -11,10 +11,20 @@ const destinations: string[] = [
   'https://nomadproject.io',
   'https://packer.io',
   'https://portal.cloud.hashicorp.com',
+  'https://registry.terraform.io',
   'https://terraform.io',
+  'https://vagrantup.com',
   'https://vaultproject.io',
   'https://waypointproject.io',
+  'https://www.boundaryproject.io',
+  'https://www.consul.io',
+  'https://www.hashicorp.com',
+  'https://www.nomadproject.io',
+  'https://www.packer.io',
+  'https://www.terraform.io',
   'https://www.vagrantup.com',
+  'https://www.vaultproject.io',
+  'https://www.waypointproject.io',
 ]
 
 const containsDestination = (str: string): boolean =>

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -13,7 +13,7 @@ const containsDestination = (str: string): boolean =>
     return str.indexOf(destination) >= 0
   })
 
-export function addAnonymousIdHandler() {
+export function addGlobalLinkHandler() {
   if (typeof window === 'undefined') return
 
   window.addEventListener('click', (event) => {

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -8,11 +8,13 @@ const destinations: string[] = [
   'https://consul.io',
   'https://developer.hashicorp.com',
   'https://hashicorp.com',
+  'https://nomadproject.io',
   'https://packer.io',
   'https://portal.cloud.hashicorp.com',
   'https://terraform.io',
   'https://vaultproject.io',
   'https://waypointproject.io',
+  'https://www.vagrantup.com',
 ]
 
 const containsDestination = (str: string): boolean =>
@@ -33,7 +35,7 @@ export function addGlobalLinkHandler(
     const linkElement = (event.target as HTMLElement).closest('a')
 
     if (linkElement && containsDestination(linkElement.href)) {
-      const segmentAnonymousId = getSafeSegmentId()
+      const segmentAnonymousId = getSegmentAnonymousId()
       const productIntent = getProductIntentFromURL()
       const utmParams = getUTMParamsCaptureState()
 
@@ -72,7 +74,7 @@ export function addGlobalLinkHandler(
   hasHandler = true
 }
 
-function getSafeSegmentId(): string | null {
+function getSegmentAnonymousId(): string | null {
   if (
     typeof window !== undefined &&
     window.analytics &&

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -1,11 +1,14 @@
 const destinations: string[] = [
-  'hashicorp.com',
-  'terraform.io',
-  'consul.io',
-  'vaultproject.io',
-  'waypointproject.io',
-  'packer.io',
-  'boundaryproject.io',
+  'https://app.terraform.io',
+  'https://boundaryproject.io',
+  'https://cloud.hashicorp.com',
+  'https://consul.io',
+  'https://hashicorp.com',
+  'https://packer.io',
+  'https://portal.cloud.hashicorp.com',
+  'https://terraform.io',
+  'https://vaultproject.io',
+  'https://waypointproject.io',
 ]
 
 const containsDestination = (str: string): boolean =>
@@ -13,22 +16,25 @@ const containsDestination = (str: string): boolean =>
     return str.indexOf(destination) >= 0
   })
 
-export function addGlobalLinkHandler() {
-  if (typeof window === 'undefined') return
+// Track if we've setup this handler already to prevent registering the handler
+// multiple times.
+let hasHandler = false
+
+export function addGlobalLinkHandler(
+  callback?: (destinationUrl: string) => void
+) {
+  if (typeof window === 'undefined' || hasHandler) return
 
   window.addEventListener('click', (event) => {
     const linkElement = (event.target as HTMLElement).closest('a')
-    if (
-      linkElement &&
-      containsDestination(linkElement.href) &&
-      isValidUrl(linkElement.href)
-    ) {
+    if (linkElement && containsDestination(linkElement.href)) {
       event.preventDefault()
       const url = new URL(linkElement.href)
       const ajs_uid = safeGetSegmentId()
       if (ajs_uid) {
         url.searchParams.append('ajs_uid', ajs_uid)
       }
+      callback && callback(url.href)
       if (
         linkElement.getAttribute('target') === '_blank' ||
         event.ctrlKey ||
@@ -40,14 +46,8 @@ export function addGlobalLinkHandler() {
       }
     }
   })
-}
 
-function isValidUrl(url: string): boolean {
-  try {
-    return Boolean(new URL(url))
-  } catch (e) {
-    return false
-  }
+  hasHandler = true
 }
 
 function safeGetSegmentId(): string | null {

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -44,7 +44,13 @@ export function addGlobalLinkHandler(
   window.addEventListener('click', (event) => {
     const linkElement = (event.target as HTMLElement).closest('a')
 
-    if (linkElement && containsDestination(linkElement.href)) {
+    if (
+      linkElement &&
+      containsDestination(
+        (linkElement as HTMLAnchorElement).attributes.getNamedItem('href')!
+          .value
+      )
+    ) {
       const segmentAnonymousId = getSegmentAnonymousId()
       const productIntent = getProductIntentFromURL()
       const utmParams = getUTMParamsCaptureState()

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -44,7 +44,7 @@ export function addGlobalLinkHandler(
       const url = new URL(linkElement.href)
 
       if (segmentAnonymousId) {
-        url.searchParams.set('ajs_uid', segmentAnonymousId)
+        url.searchParams.set('ajs_aid', segmentAnonymousId)
       }
 
       if (productIntent) {

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -6,6 +6,7 @@ const destinations: string[] = [
   'https://boundaryproject.io',
   'https://cloud.hashicorp.com',
   'https://consul.io',
+  'https://developer.hashicorp.com',
   'https://hashicorp.com',
   'https://packer.io',
   'https://portal.cloud.hashicorp.com',

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -55,9 +55,14 @@ export function addGlobalLinkHandler(
       const productIntent = getProductIntentFromURL()
       const utmParams = getUTMParamsCaptureState()
 
-      event.preventDefault()
-
       const url = new URL(linkElement.href)
+
+      // Safegaurd against absolute URLs that are on the same domain origin
+      if (window.location.origin === url.origin) {
+        return
+      }
+
+      event.preventDefault()
 
       if (segmentAnonymousId) {
         url.searchParams.set('ajs_aid', segmentAnonymousId)

--- a/packages/analytics/add-global-link-handler/index.ts
+++ b/packages/analytics/add-global-link-handler/index.ts
@@ -1,3 +1,6 @@
+import { getProductIntentFromURL } from '../get-product-intent-from-url'
+import { getUTMParamsCaptureState } from '../utm-params-capture'
+
 const destinations: string[] = [
   'https://app.terraform.io',
   'https://boundaryproject.io',
@@ -28,13 +31,30 @@ export function addGlobalLinkHandler(
   window.addEventListener('click', (event) => {
     const linkElement = (event.target as HTMLElement).closest('a')
     if (linkElement && containsDestination(linkElement.href)) {
+      const segmentAnonymousId = safeGetSegmentId()
+      const productIntent = getProductIntentFromURL()
+      const utmParams = getUTMParamsCaptureState()
+
       event.preventDefault()
+
       const url = new URL(linkElement.href)
-      const ajs_uid = safeGetSegmentId()
-      if (ajs_uid) {
-        url.searchParams.append('ajs_uid', ajs_uid)
+
+      if (segmentAnonymousId) {
+        url.searchParams.append('ajs_uid', segmentAnonymousId)
       }
+
+      if (productIntent) {
+        url.searchParams.append('product_intent', productIntent)
+      }
+
+      if (Object.keys(utmParams).length > 0) {
+        for (const [key, value] of Object.entries(utmParams)) {
+          url.searchParams.set(key, value)
+        }
+      }
+
       callback && callback(url.href)
+
       if (
         linkElement.getAttribute('target') === '_blank' ||
         event.ctrlKey ||

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -7,6 +7,7 @@ export {
   getUTMParamsCaptureState,
 } from './utm-params-capture'
 export { addCloudLinkHandler } from './add-cloud-link-handler'
+export { addGlobalLinkHandler } from './add-global-link-handler'
 
 export { addDevAnalyticsLogger } from './analytics-event-logger'
 


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1203227460033456/1203227460033463/f)

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->

This PR introduces `addGlobalLinkHandler` to replace `addCloudLinkHandler` functionality and adds the passing of Segment Anonymous ID within the search params.

- Navigate to https://hashicorp-www-next-33szo9g6y-hashicorp.vercel.app/products/vault?utm_source=example
- Click Sign up for HCP Vault button in hero
- You should be taken to https://cloud.hashicorp.com/products/vault and ajs_aid, product_intent, and utm_source should be passed along as search params within the URL.

A bit harder to test is that those search params should persist in the URL across domains.