### PR TITLE
Add reusable workflow, and add secrets

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,6 +1,12 @@
 name: Canary Release
 
 on:
+  workflow_call:
+  secrets:
+    GITHUB_TOKEN:
+      required: true
+    NPM_TOKEN:
+      required: true
   pull_request:
     types:
       - opened

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -3,7 +3,7 @@ name: Canary Release
 on:
   workflow_call:
   secrets:
-    GITHUB_TOKEN:
+    PUBLISH_GITHUB_TOKEN:
       required: true
     NPM_TOKEN:
       required: true
@@ -34,7 +34,7 @@ jobs:
       - name: Version
         run: npx changeset version --snapshot canary
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_GITHUB_TOKEN }}
 
       - name: Publish Canary Packages
         id: changesets
@@ -43,7 +43,7 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release:canary
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Compute new packages info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
 on:
+  workflow_call:
+  secrets:
+    PUBLISH_GITHUB_TOKEN:
+      required: true
+    NPM_TOKEN:
+      required: true
   push:
     branches:
       - main

--- a/package-lock.json
+++ b/package-lock.json
@@ -40370,7 +40370,7 @@
     "@hashicorp/platform-analytics": {
       "version": "file:packages/analytics",
       "requires": {
-        "@segment/analytics-next": "*",
+        "@segment/analytics-next": "^1.45.0",
         "fathom-client": "^3.2.0",
         "js-cookie": "^2.2.1"
       }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1202025665826447/f)

---

## Description
This ticket enables developers to publish packages to NPM with little configuration, and eliminates the need to create duplicate workflows throughout the org.

[Reusable workflow docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow)

### As a developer:
**I want:**
The ability to access a reusable release workflow .yml file that allows me to publish to NPM.

**I don't want:**
To be required to create a duplicate a release workflow .yml file that exists within the GitHub org.

### Known issues:
Due to the E2E testing limitations of GitHub actions, we will have to manually test these changes.

## PR Checklist 🚀

- [X] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [X] Write a useful description (above) to give reviewers appropriate context.
- [X] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
