### PR TITLE
fix: workflow_call indentation

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -2,11 +2,11 @@ name: Canary Release
 
 on:
   workflow_call:
-  secrets:
-    PUBLISH_GITHUB_TOKEN:
-      required: true
-    NPM_TOKEN:
-      required: true
+    secrets:
+      PUBLISH_GITHUB_TOKEN:
+        required: true
+      NPM_TOKEN:
+        required: true
   pull_request:
     types:
       - opened

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,11 @@ name: Release
 
 on:
   workflow_call:
-  secrets:
-    PUBLISH_GITHUB_TOKEN:
-      required: true
-    NPM_TOKEN:
-      required: true
+    secrets:
+      PUBLISH_GITHUB_TOKEN:
+        required: true
+      NPM_TOKEN:
+        required: true
   push:
     branches:
       - main


### PR DESCRIPTION
This fixes `workflow_call.secrets` indentation for the `release` and `canary-release` workflows

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
