### PR TITLE
feat(content-conformance): add ensure-valid-nav-data rule

### DIFF
--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-nav-data.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-nav-data.test.ts
@@ -1,0 +1,156 @@
+import { testRule } from '../../test/utils.js'
+
+import ensureValidNavData from '../ensure-valid-nav-data.js'
+
+describe('ensure-valid-nav-data', () => {
+  test('ignores files that do not end in nav-data.json', () => {
+    testRule(ensureValidNavData, [
+      {
+        fixture: {
+          path: 'something-else.json',
+          value: JSON.stringify([]),
+        },
+        messages: [],
+      },
+    ])
+  })
+
+  test('empty nav data', () => {
+    testRule(ensureValidNavData, [
+      {
+        fixture: {
+          path: 'nav-data.json',
+          value: JSON.stringify([]),
+        },
+        messages: [
+          'Found empty array of navNodes at depth 0. There must be more than one route.',
+        ],
+      },
+    ])
+  })
+
+  test('empty routes', () => {
+    testRule(ensureValidNavData, [
+      {
+        fixture: {
+          path: 'nav-data.json',
+          value: JSON.stringify([
+            {
+              title: 'Directory',
+              routes: [],
+            },
+          ]),
+        },
+        messages: [
+          'Found empty array of navNodes at depth 1. There must be more than one route.',
+        ],
+      },
+    ])
+  })
+
+  test('missing title', () => {
+    testRule(ensureValidNavData, [
+      {
+        fixture: {
+          path: 'nav-data.json',
+          value: JSON.stringify([
+            {
+              title: 'Directory',
+              routes: [
+                {
+                  path: '/about',
+                },
+              ],
+            },
+          ]),
+        },
+        messages: [
+          'Missing nav-data title. Please add a non-empty title to the node with the path "/about".',
+        ],
+      },
+    ])
+  })
+
+  test('sibling routes with different parents', () => {
+    testRule(ensureValidNavData, [
+      {
+        fixture: {
+          path: 'nav-data.json',
+          value: JSON.stringify([
+            {
+              title: 'Directory',
+              routes: [
+                {
+                  title: 'Overview',
+                  path: 'directory',
+                },
+                {
+                  title: 'Valid Parent',
+                  path: 'directory/some-file',
+                },
+                {
+                  title: 'Invalid Parent',
+                  path: 'another-directory/another-file',
+                },
+              ],
+            },
+          ]),
+        },
+        messages: [
+          `Found mismatched paths at depth 1, with paths: ["directory","directory/some-file","another-directory/another-file"]. Implies mismatched parent directories: ["directory","another-directory"].`,
+        ],
+      },
+    ])
+  })
+
+  test('duplicate routes', () => {
+    testRule(ensureValidNavData, [
+      {
+        fixture: {
+          path: 'nav-data.json',
+          value: JSON.stringify([
+            {
+              title: 'Directory Dupe',
+              path: 'directory',
+            },
+            {
+              title: 'Directory',
+              routes: [
+                {
+                  title: 'Overview',
+                  path: 'directory',
+                },
+                {
+                  title: 'Some File',
+                  path: 'directory/some-file',
+                },
+              ],
+            },
+          ]),
+        },
+        messages: [
+          `Duplicate routes found for "directory". Please resolve duplicates.`,
+        ],
+      },
+    ])
+  })
+
+  test('empty href', () => {
+    testRule(ensureValidNavData, [
+      {
+        fixture: {
+          path: 'nav-data.json',
+          value: JSON.stringify([
+            {
+              title: 'Empty Href Link',
+              href: '',
+            },
+          ]),
+        },
+        messages: [
+          `Empty href value on NavDirectLink. href values must be non-empty strings. Node: {"title":"Empty Href Link","href":""}.`,
+        ],
+      },
+    ])
+  })
+})

--- a/packages/content-conformance/src/rules/ensure-valid-nav-data.js
+++ b/packages/content-conformance/src/rules/ensure-valid-nav-data.js
@@ -1,0 +1,161 @@
+function visitor(navNodes, report, depth = 0) {
+  //  In order to be a valid branch, there needs to be at least one navNode.
+  if (navNodes.length === 0) {
+    report(
+      `Found empty array of navNodes at depth ${depth}. There must be more than one route.`
+    )
+  }
+
+  // Augment each navNode with its path __stack
+  const navNodesWithStacks = navNodes.map((navNode) => {
+    // Handle leaf nodes - split their paths into a __stack
+    if (typeof navNode.path !== 'undefined') {
+      if (!navNode.title) {
+        report(
+          `Missing nav-data title. Please add a non-empty title to the node with the path "${navNode.path}".`
+        )
+      }
+      return { ...navNode, __stack: navNode.path.split('/') }
+    }
+    // Handle branch nodes - we recurse depth-first here
+    if (navNode.routes) {
+      const nodeWithStacks = handleBranchNode(navNode, report, depth)
+      if (!navNode.title) {
+        const branchPath = nodeWithStacks.__stack.join('/')
+        report(
+          `Missing nav-data title on NavBranch. Please add a title to the node with the inferred path "${branchPath}".`
+        )
+      }
+      return nodeWithStacks
+    }
+    // Handle direct link nodes, identifiable
+    // by the presence of an href, to ensure they have a title
+    if (typeof navNode.href !== 'undefined') {
+      if (navNode.href == '') {
+        report(
+          `Empty href value on NavDirectLink. href values must be non-empty strings. Node: ${JSON.stringify(
+            navNode
+          )}.`
+        )
+      }
+      if (!navNode.title) {
+        report(
+          `Missing nav-data title on NavDirectLink. Please add a title to the node with href "${navNode.href}".`
+        )
+      }
+      // Otherwise, we have a valid direct link node, we return it
+      return navNode
+    }
+    // Ensure the only other node type is
+    // a divider node, if not, throw an error
+    if (!(navNode.divider || navNode.heading)) {
+      report(
+        `Unrecognized nav-data node. Please ensure all nav-data nodes are either NavLeaf, NavBranch, NavDirectLink, NavHeading, or NavDivider types. Invalid node: ${JSON.stringify(
+          navNode
+        )}.`
+      )
+    }
+    // Other nodes, really just divider nodes,
+    // aren't relevant, so we don't touch them
+    return navNode
+  })
+  // Gather all the path stacks at this level
+  const routeStacks = navNodesWithStacks.reduce((acc, navNode) => {
+    // Ignore nodes that don't have a path stack
+    if (!navNode.__stack) return acc
+    // For other nodes, add their stacks
+    return acc.concat([navNode.__stack])
+  }, [])
+  // Ensure that there are no duplicate routes
+  // (for example, a nested route with a particular path,
+  // and a named page at the same level with the same path)
+  const routePaths = routeStacks.map((s) => s.join('/'))
+  const duplicateRoutes = routePaths.filter((value, index, self) => {
+    return self.indexOf(value) !== index
+  })
+  if (duplicateRoutes.length > 0) {
+    report(
+      `Duplicate routes found for "${duplicateRoutes[0]}". Please resolve duplicates.`
+    )
+  }
+  // Gather an array of all resolved paths at this level
+  const parentRoutes = routeStacks.map((stack) => {
+    // Index leaf nodes will have the same
+    // number of path parts as the current nesting depth.
+    const isIndexNode = stack.length === depth
+    if (isIndexNode) {
+      // The "dirPath" for index nodes is
+      // just the original path
+      return stack.join('/')
+    }
+    // Named leaf nodes, and nested routes,
+    // will have one more path part than the current nesting depth.
+    const isNamedNode = stack.length === depth + 1
+    if (isNamedNode) {
+      // The "dirPath" for named nodes is
+      // the original path with the last part dropped.
+      return stack.slice(0, stack.length - 1).join('/')
+    }
+    // If we have any other number of parts in the
+    // leaf node's path, then it is invalid.
+    report(
+      `Invalid path depth. At depth ${depth}, found path "${stack.join(
+        '/'
+      )}". Please move this path to the correct depth of ${stack.length - 1}.`
+    )
+  })
+  // We expect all routes at any level to share the same parent directory.
+  // In other words, we expect there to be exactly one unique "dirPath"
+  // shared across all the routes at this level.
+  const uniqueParents = parentRoutes.filter((value, index, self) => {
+    return self.indexOf(value) === index
+  })
+  // We throw an error if we find mismatched paths
+  // that don't share the same parent path.
+  if (uniqueParents.length > 1) {
+    report(
+      `Found mismatched paths at depth ${depth}, with paths: ${JSON.stringify(
+        routePaths
+      )}. Implies mismatched parent directories: ${JSON.stringify(
+        uniqueParents
+      )}.`
+    )
+  }
+
+  // Note: some branches may not have any children with paths,
+  // for example branches with only direct links. So, path may be undefined.
+  const path = uniqueParents[0]
+  //  Finally, we return
+  return [path, navNodesWithStacks]
+}
+
+function handleBranchNode(navNode, report, depth) {
+  // We recurse depth-first here, and we'll throw an error
+  // if any nested routes have structural issues
+  const [path, routesWithStacks] = visitor(navNode.routes, report, depth + 1)
+  // Path will be undefined if the child routes are
+  // only non-path nodes (such as direct links).
+  // In this case, we set __stack to false so this route
+  // is left out of tree structure validation
+  const __stack = !path ? false : path.split('/')
+  return { ...navNode, __stack, routes: routesWithStacks }
+}
+
+/** @type {import('../types.js').ConformanceRuleBase} */
+export default {
+  id: 'ensure-valid-nav-data',
+  type: 'data',
+  description: 'Ensures docs nav data files are properly formatted.',
+  executor: {
+    dataFile(file, context) {
+      // by convention, nav data files are those that end in nav-data.json
+      if (!file.basename.endsWith('nav-data.json')) {
+        return
+      }
+
+      const report = (message) => context.report(message, file)
+
+      visitor(file.contents(), report)
+    },
+  },
+}

--- a/packages/content-conformance/src/test/utils.ts
+++ b/packages/content-conformance/src/test/utils.ts
@@ -82,7 +82,16 @@ export function testRule(
       }
     }
 
-    expect(() =>
+    // Handle the case where messages is empty, indicating we aren't expecting any messages to be reported.
+    if (testCase.messages.length === 0 && file.messages.length > 0) {
+      const err = new Error(`Expected no reported messages, but found:
+${file.messages.map(({ reason }) => `\t- ${reason}`).join('\n')}`)
+      err.stack = undefined
+
+      throw err
+    }
+
+    expect(() => {
       testCase.messages.every((message: string | RegExp) => {
         const match = file.messages.some((msg) => {
           if (typeof message === 'string') {
@@ -105,7 +114,7 @@ to contain message matching:
           throw err
         }
       })
-    ).not.toThrow()
+    }).not.toThrow()
   }
 
   for (const testCase of testCases) {

--- a/packages/content-conformance/src/test/utils.ts
+++ b/packages/content-conformance/src/test/utils.ts
@@ -1,5 +1,9 @@
 import path from 'path'
 import url from 'url'
+import { VFileCompatible } from 'vfile'
+import { ContentFile } from '../content-file.js'
+import { DataFile } from '../data-file.js'
+import { ConformanceRuleBase, ConformanceRuleContext } from '../types.js'
 
 const currentFilePath = url.fileURLToPath(new URL(import.meta.url))
 
@@ -11,4 +15,100 @@ export function getFixturePath(fixtureName: string) {
     '__fixtures__',
     fixtureName
   )
+}
+
+function makeTestFileAndContext(rule: ConformanceRuleBase, fixture: string) {
+  let file
+  const context: ConformanceRuleContext = {
+    dataFiles: [],
+    contentFiles: [],
+    report: () => {
+      void 0
+    },
+  }
+
+  switch (rule.type) {
+    case 'data': {
+      file = new DataFile(fixture)
+      context.dataFiles = [file]
+      break
+    }
+    default:
+    case 'content': {
+      file = new ContentFile(fixture)
+      context.contentFiles = [file]
+      break
+    }
+  }
+
+  context.report = (message, file, node) => {
+    if (file) {
+      file.message(message, node, rule.id)
+    }
+  }
+
+  return [file, context] as const
+}
+
+/**
+ * A test helper to write assertions against a conformance rule.
+ *
+ * Usage:
+ *
+ * ```js
+ * testRule(myRule, [{ fixture: JSON.stringify([]), messages: ['No empty array'] }])
+ * ```
+ */
+export function testRule(
+  rule: ConformanceRuleBase,
+  testCases: { fixture: VFileCompatible; messages: (string | RegExp)[] }[]
+) {
+  function test(testCase: any) {
+    const [file, context] = makeTestFileAndContext(rule, testCase.fixture)
+
+    switch (rule.type) {
+      case 'data': {
+        rule.executor?.dataFile?.(
+          file as DataFile,
+          context as ConformanceRuleContext
+        )
+        break
+      }
+      case 'content': {
+        rule.executor?.contentFile?.(
+          file as ContentFile,
+          context as ConformanceRuleContext
+        )
+      }
+    }
+
+    expect(() =>
+      testCase.messages.every((message: string | RegExp) => {
+        const match = file.messages.some((msg) => {
+          if (typeof message === 'string') {
+            return msg.reason === message
+          } else {
+            return msg.message.match(message)
+          }
+        })
+
+        if (!match) {
+          const err = new Error(
+            `\nexpected reported messages:
+${file.messages.map(({ reason }) => `\t- ${reason}`).join('\n')}
+to contain message matching:
+  ${message}`
+          )
+
+          err.stack = undefined
+
+          throw err
+        }
+      })
+    ).not.toThrow()
+  }
+
+  for (const testCase of testCases) {
+    test(testCase)
+  }
 }


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->
- Ports our [existing nav-data validations](https://github.com/hashicorp/react-components/blob/main/packages/docs-sidenav/utils/validate-route-structure/index.ts) into a conformance rule.
- Adds a utility to test rules in isolation, called `testRule()`.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203414786494809