### PR TITLE
feat(content-conformance): add ensure-valid-link-format rule

### DIFF
--- a/.changeset/wicked-dolphins-beg.md
+++ b/.changeset/wicked-dolphins-beg.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-content-conformance': patch
+---
+
+Adds `ensure-valid-link-format` rule.

--- a/packages/content-conformance/src/configs/base-docs.js
+++ b/packages/content-conformance/src/configs/base-docs.js
@@ -11,6 +11,6 @@ export default {
     'ensure-valid-nav-paths': 'error',
     'no-link-in-heading': 'error',
     'no-unlinked-pages': 'error',
-    'ensure-valid-link-format': 'error',
+    'ensure-valid-link-format': ['error', { contentType: 'docs' }],
   },
 }

--- a/packages/content-conformance/src/configs/base-docs.js
+++ b/packages/content-conformance/src/configs/base-docs.js
@@ -11,5 +11,6 @@ export default {
     'ensure-valid-nav-paths': 'error',
     'no-link-in-heading': 'error',
     'no-unlinked-pages': 'error',
+    'ensure-valid-link-format': 'error',
   },
 }

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -21,6 +21,22 @@ describe('ensure-valid-link-format', () => {
         fixture: `[I am a valid collection link](/boundary/tutorials/foo)`,
         messages: [],
       },
+      {
+        fixture: `[I am a valid WAF collection link](/well-architected-framework/foo)`,
+        messages: [],
+      },
+      {
+        fixture: `[I am a valid onboarding collection link](/onboarding/foo)`,
+        messages: [],
+      },
+      {
+        fixture: `[I am a valid WAF tutorial link](/well-architected-framework/foo/bar)`,
+        messages: [],
+      },
+      {
+        fixture: `[I am a valid onboarding tutorial link](/onboarding/foo/bar)`,
+        messages: [],
+      },
     ])
   })
 

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -131,7 +131,15 @@ describe('ensure-valid-link-format', () => {
   test('errors for folder-relative links', () => {
     testRule(ensureValidLinkFormat, [
       {
-        fixture: `[folder-relative link](./foo/bar)`,
+        fixture: `[dot-slash folder-relative link](./foo/bar)`,
+        messages: [/Unexpected folder-relative link/],
+      },
+      {
+        fixture: `[dot-dot-slash folder-relative link](../foo/bar)`,
+        messages: [/Unexpected folder-relative link/],
+      },
+      {
+        fixture: `[no-dots folder-relative link](foo/bar)`,
         messages: [/Unexpected folder-relative link/],
       },
     ])

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -46,6 +46,15 @@ describe('ensure-valid-link-format', () => {
         [I am a valid link to another .io domain](https://terraform.io)`,
         messages: [],
       },
+      {
+        fixture: `[I am a valid link to an .io domain](https://waypointproject.io/not/a/docs/path/)
+        [I am a valid link to another .io domain](https://terraform.io/not/a/docs/path)`,
+        messages: [],
+      },
+      {
+        fixture: `[I am a valid external link](https://github.com/hashicorp/web-platform-packages)`,
+        messages: [],
+      },
     ])
   })
 

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -6,6 +6,10 @@ describe('ensure-valid-link-format', () => {
   test('does nothing for valid developer links', () => {
     testRule(ensureValidLinkFormat, [
       {
+        fixture: `[I am a valid link](/non/product/path)`,
+        messages: [],
+      },
+      {
         fixture: `[I am a valid link](/waypoint/docs/foo/bar)`,
         messages: [],
       },

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -1,0 +1,136 @@
+import { testRule } from '../../test/utils'
+
+import ensureValidLinkFormat from '../ensure-valid-link-format'
+
+describe('ensure-valid-link-format', () => {
+  test('does nothing for valid developer links', () => {
+    testRule(ensureValidLinkFormat, [
+      {
+        fixture: `[I am a valid link](/waypoint/docs/foo/bar)`,
+        messages: [],
+      },
+      {
+        fixture: `[I am a valid link](/boundary/docs/foo/bar)`,
+        messages: [],
+      },
+      {
+        fixture: `[I am a valid tutorial link](/boundary/tutorials/foo/bar)`,
+        messages: [],
+      },
+      {
+        fixture: `[I am a valid collection link](/boundary/tutorials/foo)`,
+        messages: [],
+      },
+    ])
+  })
+
+  test('errors for learn.hashicorp.com links', () => {
+    testRule(ensureValidLinkFormat, [
+      {
+        fixture: `[learn link](https://learn.hashicorp.com/tutorials/waypoint/aws-ecs)`,
+        messages: [/Unexpected link to `learn\.hashicorp\.com`/],
+      },
+      {
+        fixture: `[invalid learn link](https://learn.hashicorp.com/tutorials/waypoint)`,
+        messages: [/Unexpected link to `learn\.hashicorp\.com`/],
+      },
+    ])
+  })
+
+  test('errors for .io site docs links', () => {
+    testRule(ensureValidLinkFormat, [
+      {
+        fixture: `[.io docs link](https://www.waypointproject.io/docs)`,
+        messages: [/Unexpected link to documentation on `waypointproject\.io`/],
+      },
+      {
+        fixture: `[.io docs link](https://waypointproject.io/docs)`,
+        messages: [/Unexpected link to documentation on `waypointproject\.io`/],
+      },
+      {
+        fixture: `[Another .io docs link](https://www.consul.io/commands)`,
+        messages: [/Unexpected link to documentation on `consul\.io`/],
+      },
+    ])
+  })
+
+  test('errors for fully qualified developer.hashicorp.com links', () => {
+    testRule(ensureValidLinkFormat, [
+      {
+        fixture: `[full developer link](https://developer.hashicorp.com)`,
+        messages: [
+          /Unexpected fully-qualified link to `developer\.hashicorp\.com`/,
+        ],
+      },
+      {
+        fixture: `[another full developer link](https://developer.hashicorp.com/tutorials/library)`,
+        messages: [
+          /Unexpected fully-qualified link to `developer\.hashicorp\.com`/,
+        ],
+      },
+      {
+        fixture: `[full developer link](https://developer.hashicorp.com/waypoint/docs)`,
+        messages: [
+          /Unexpected fully-qualified link to `developer\.hashicorp\.com`/,
+        ],
+      },
+    ])
+  })
+
+  test('errors for links without product base paths', () => {
+    testRule(ensureValidLinkFormat, [
+      {
+        fixture: `[relative docs link](/docs/foo)`,
+        messages: [/Unexpected product-relative link/],
+      },
+      {
+        fixture: `[relative docs link](/api-docs)`,
+        messages: [/Unexpected product-relative link/],
+      },
+      {
+        fixture: `[relative docs link](/commands)`,
+        messages: [/Unexpected product-relative link/],
+      },
+    ])
+  })
+
+  test('errors for folder-relative links', () => {
+    testRule(ensureValidLinkFormat, [
+      {
+        fixture: `[folder-relative link](./foo/bar)`,
+        messages: [/Unexpected folder-relative link/],
+      },
+    ])
+  })
+
+  test('tutorials-specific errors', () => {
+    testRule(
+      ensureValidLinkFormat,
+      [
+        {
+          fixture: `[search](/search)`,
+          messages: [/Old Learn search page link/],
+        },
+        {
+          fixture: `[waf](/collections/well-architected-framework)
+[onboarding](/collections/onboarding)
+[waf tutorial](/tutorials/well-architected-framework/foo)
+[onboarding tutorial](/tutorials/onboarding/foo)`,
+          messages: [
+            /Old WAF\/onboarding collection page link/,
+            /Old WAF\/onboarding tutorials page link/,
+          ],
+        },
+        {
+          fixture: `[collections](/collections)`,
+          messages: [/Old collection page link/],
+        },
+        {
+          fixture: `[tutorials](/tutorials/waypoint/blah)`,
+          messages: [/Old tutorial page link/],
+        },
+      ],
+      { isTutorials: true }
+    )
+  })
+})

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -37,6 +37,11 @@ describe('ensure-valid-link-format', () => {
         fixture: `[I am a valid onboarding tutorial link](/onboarding/foo/bar)`,
         messages: [],
       },
+      {
+        fixture: `[I am a valid link to an .io domain](https://waypointproject.io/)
+        [I am a valid link to another .io domain](https://terraform.io)`,
+        messages: [],
+      },
     ])
   })
 

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -146,7 +146,7 @@ describe('ensure-valid-link-format', () => {
           messages: [/Old tutorial page link/],
         },
       ],
-      { isTutorials: true }
+      { contentType: 'tutorials' }
     )
   })
 })

--- a/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-valid-link-format.test.ts
@@ -55,6 +55,10 @@ describe('ensure-valid-link-format', () => {
         fixture: `[I am a valid external link](https://github.com/hashicorp/web-platform-packages)`,
         messages: [],
       },
+      {
+        fixture: `[I am a valid anchor link](#foo-bar-baz)`,
+        messages: [],
+      },
     ])
   })
 

--- a/packages/content-conformance/src/rules/ensure-valid-link-format.js
+++ b/packages/content-conformance/src/rules/ensure-valid-link-format.js
@@ -97,11 +97,9 @@ export default {
         if (dotIoLinkProductSlug) {
           const devDotBasePaths =
             PRODUCT_SLUGS_TO_BASE_PATHS[dotIoLinkProductSlug]
-          const isDevDotBasePath =
-            pathname === '/' ||
-            devDotBasePaths.some((devDotBasePath) => {
-              return pathname.startsWith(`/${devDotBasePath}`)
-            })
+          const isDevDotBasePath = devDotBasePaths.some((devDotBasePath) => {
+            return pathname.startsWith(`/${devDotBasePath}`)
+          })
           if (isDevDotBasePath) {
             context.report(
               `Unexpected link to documentation on \`${

--- a/packages/content-conformance/src/rules/ensure-valid-link-format.js
+++ b/packages/content-conformance/src/rules/ensure-valid-link-format.js
@@ -73,12 +73,14 @@ export default {
         const urlObject = new URL(node.url, TEST_URL_ORIGIN)
         const { hostname, pathname, search = '', hash = '', origin } = urlObject
         const isRelativePath = origin === TEST_URL_ORIGIN
+        const isAnchorLink = node.url.startsWith('#')
 
         // Error if we detect folder-relative links
         if (
-          node.url.startsWith('.') ||
-          // Handles folder-relative links such as "some/nested/folder". These can be problematic when trying to validate the correct destination. It's easier for us to enforce that all links are full paths.
-          (!node.url.startsWith('/') && isRelativePath)
+          !isAnchorLink &&
+          (node.url.startsWith('.') ||
+            // Handles folder-relative links such as "some/nested/folder". These can be problematic when trying to validate the correct destination. It's easier for us to enforce that all links are full paths.
+            (!node.url.startsWith('/') && isRelativePath))
         ) {
           context.report(
             `Unexpected folder-relative link found: ${node.url}. Ensure this link is an absolute Developer path.`,

--- a/packages/content-conformance/src/rules/ensure-valid-link-format.js
+++ b/packages/content-conformance/src/rules/ensure-valid-link-format.js
@@ -93,6 +93,7 @@ export default {
             hostname === `www.${PRODUCT_SLUGS_TO_HOST_NAMES[productSlug]}`
           )
         })
+
         if (dotIoLinkProductSlug) {
           const devDotBasePaths =
             PRODUCT_SLUGS_TO_BASE_PATHS[dotIoLinkProductSlug]

--- a/packages/content-conformance/src/rules/ensure-valid-link-format.js
+++ b/packages/content-conformance/src/rules/ensure-valid-link-format.js
@@ -1,0 +1,186 @@
+const TEST_URL_ORIGIN = 'https://test.com'
+const LEARN_HOSTNAME = 'learn.hashicorp.com'
+const DEV_DOT_HOSTNAME = 'developer.hashicorp.com'
+
+const PRODUCT_SLUGS_TO_HOST_NAMES = {
+  boundary: 'boundaryproject.io',
+  consul: 'consul.io',
+  hcp: 'cloud.hashicorp.com',
+  nomad: 'nomadproject.io',
+  packer: 'packer.io',
+  terraform: 'terraform.io',
+  vagrant: 'vagrantup.com',
+  vault: 'vaultproject.io',
+  waypoint: 'waypointproject.io',
+}
+
+// TODO(brkalow): it would be good to have this come from a shared source
+const PRODUCT_SLUGS_TO_BASE_PATHS = {
+  boundary: ['docs', 'api-docs', 'downloads'],
+  consul: ['docs', 'api-docs', 'commands', 'downloads'],
+  hcp: ['docs', 'api-docs'],
+  nomad: ['docs', 'api-docs', 'plugins', 'tools', 'intro', 'downloads'],
+  packer: ['docs', 'guides', 'intro', 'plugins', 'downloads'],
+  terraform: [
+    'cdktf',
+    'cli',
+    'cloud-docs',
+    'cloud-docs/agents',
+    'docs',
+    'enterprise',
+    'internals',
+    'intro',
+    'language',
+    'plugin',
+    'plugin/framework',
+    'plugin/log',
+    'plugin/mux',
+    'plugin/sdkv2',
+    'registry',
+    'downloads',
+  ],
+  vagrant: ['docs', 'intro', 'vagrant-cloud', 'vmware', 'downloads'],
+  vault: ['docs', 'api-docs', 'intro', 'downloads', 'downloads'],
+  waypoint: ['commands', 'docs', 'plugins', 'downloads'],
+}
+
+const PRODUCT_SLUG_PATH_PATTERN = new RegExp(
+  `^/(${Object.keys(PRODUCT_SLUGS_TO_HOST_NAMES).join('|')})`
+)
+
+/** @type {import('../types.js').ConformanceRuleBase} */
+export default {
+  id: 'ensure-valid-link-format',
+  type: 'content',
+  description:
+    'Ensures that internal links conform to the path structure of the Developer platform.',
+  executor: {
+    contentFile(file, context) {
+      file.visit(['link', 'definition'], (node) => {
+        const urlObject = new URL(node.url, TEST_URL_ORIGIN)
+        const { hostname, pathname, search = '', hash = '', origin } = urlObject
+        const isRelativePath = origin === TEST_URL_ORIGIN
+
+        // Error if we detect folder-relative links
+        if (node.url.startsWith('.')) {
+          context.report(
+            `Unexpected folder-relative link found: ${node.url}. Ensure this link is an absolute Developer path.`,
+            file,
+            node
+          )
+          return
+        }
+
+        // Check for .io hostname
+        const dotIoLinkProductSlug = Object.keys(
+          PRODUCT_SLUGS_TO_HOST_NAMES
+        ).find((productSlug) => {
+          return (
+            hostname === PRODUCT_SLUGS_TO_HOST_NAMES[productSlug] ||
+            hostname === `www.${PRODUCT_SLUGS_TO_HOST_NAMES[productSlug]}`
+          )
+        })
+        if (dotIoLinkProductSlug) {
+          const devDotBasePaths =
+            PRODUCT_SLUGS_TO_BASE_PATHS[dotIoLinkProductSlug]
+          const isDevDotBasePath =
+            pathname === '/' ||
+            devDotBasePaths.some((devDotBasePath) => {
+              return pathname.startsWith(`/${devDotBasePath}`)
+            })
+          if (isDevDotBasePath) {
+            context.report(
+              `Unexpected link to documentation on \`${
+                PRODUCT_SLUGS_TO_HOST_NAMES[dotIoLinkProductSlug]
+              }\`: \`${
+                node.url
+              }\`. Try replacing it with \`${`/${dotIoLinkProductSlug}${
+                pathname === '/' ? '' : pathname
+              }`}\``,
+              file,
+              node
+            )
+          }
+        }
+
+        // Check for learn hostname
+        if (hostname === LEARN_HOSTNAME) {
+          context.report(
+            `Unexpected link to \`learn.hashicorp.com\`: \`${node.url}\`. Replace it with a relative path internal to Developer with the format: \`/{productSlug}/tutorials/{collectionSlug}/{tutorialSlug}\`.`,
+            file,
+            node
+          )
+        }
+
+        // Check for developer hostname
+        if (hostname === DEV_DOT_HOSTNAME) {
+          context.report(
+            `Unexpected fully-qualified link to \`developer.hashicorp.com\`: \`${node.url}\`. Replace with a relative path internal to Developer. Possibly: \`${pathname}${search}${hash}\`.`,
+            file,
+            node
+          )
+        }
+
+        // handle product-relative paths
+        if (isRelativePath && !pathname.match(PRODUCT_SLUG_PATH_PATTERN)) {
+          context.report(
+            `Unexpected product-relative link: \`${node.url}\`. Ensure that relative links are fully-qualified Developer paths: \`/{productSlug}${pathname}\``,
+            file,
+            node
+          )
+        }
+
+        // if we're running in the context of tutorials, check for specific old link formats
+        if (context.config?.isTutorials) {
+          // Check if old search link (starts with "/search")
+          if (
+            pathname.startsWith('/search') &&
+            (hostname === LEARN_HOSTNAME || isRelativePath)
+          ) {
+            context.report(
+              `Old Learn search page link: \`${node.url}\`. Replace it with \`/tutorials/library${search}${hash}\`.`,
+              file,
+              node
+            )
+          }
+
+          // Check if one of old collection links
+          if (
+            pathname.startsWith('/collections/well-architected-framework') ||
+            pathname.startsWith('/collections/onboarding')
+          ) {
+            context.report(
+              `Old WAF/onboarding collection page link: \`${node.url}\`. WAF/onboarding collection links should be formatted like: \`/{well-architected-framework|onboarding}/{collectionSlug}\``,
+              file,
+              node
+            )
+          } else if (pathname.startsWith('/collections')) {
+            context.report(
+              `Old collection page link: \`${node.url}\`. Collections links should be formatted like: \`/{productSlug}/tutorials/{collectionSlug}\`.`,
+              file,
+              node
+            )
+          }
+
+          // Check if one of old tutorial links
+          if (
+            pathname.startsWith('/tutorials/well-architected-framework') ||
+            pathname.startsWith('/tutorials/onboarding')
+          ) {
+            context.report(
+              `Old WAF/onboarding tutorials page link: \`${node.url}\`. WAF/onboarding tutorial links should be formatted like: \`/{well-architected-framework|onboarding}/{collectionSlug}/{tutorialSlug}\``,
+              file,
+              node
+            )
+          } else if (pathname.startsWith('/tutorials')) {
+            context.report(
+              `Old tutorial page link: \`${node.url}\`. Tutorials links should be formatted like: \`/{productSlug}/tutorials/{collectionSlug}/{tutorialSlug}\`.`,
+              file,
+              node
+            )
+          }
+        }
+      })
+    },
+  },
+}

--- a/packages/content-conformance/src/rules/ensure-valid-link-format.js
+++ b/packages/content-conformance/src/rules/ensure-valid-link-format.js
@@ -44,6 +44,15 @@ const PRODUCT_SLUGS_TO_BASE_PATHS = {
   waypoint: ['commands', 'docs', 'plugins', 'downloads'],
 }
 
+const KNOWN_DOCS_BASE_PATHS = Array.from(
+  // this ensures the values are unique
+  new Set(
+    Object.values(PRODUCT_SLUGS_TO_BASE_PATHS)
+      .flat()
+      .map((basePath) => `/${basePath}`)
+  )
+)
+
 const PRODUCT_SLUG_PATH_PATTERN = new RegExp(
   `^/(${Object.keys(PRODUCT_SLUGS_TO_HOST_NAMES).join('|')})`
 )
@@ -122,7 +131,15 @@ export default {
         }
 
         // handle product-relative paths
-        if (isRelativePath && !pathname.match(PRODUCT_SLUG_PATH_PATTERN)) {
+        if (
+          isRelativePath &&
+          // ignore any paths starting with /{productSlug}
+          !pathname.match(PRODUCT_SLUG_PATH_PATTERN) &&
+          // check paths that start with a known docs base path
+          KNOWN_DOCS_BASE_PATHS.some((basePath) =>
+            pathname.startsWith(basePath)
+          )
+        ) {
           context.report(
             `Unexpected product-relative link: \`${node.url}\`. Ensure that relative links are fully-qualified Developer paths: \`/{productSlug}${pathname}\``,
             file,

--- a/packages/content-conformance/src/rules/ensure-valid-link-format.js
+++ b/packages/content-conformance/src/rules/ensure-valid-link-format.js
@@ -57,7 +57,11 @@ const PRODUCT_SLUG_PATH_PATTERN = new RegExp(
   `^/(${Object.keys(PRODUCT_SLUGS_TO_HOST_NAMES).join('|')})`
 )
 
-/** @type {import('../types.js').ConformanceRuleBase} */
+/**
+ * Configurable via a contentType config option (`"docs" | "tutorials"`). Assumed to be `"docs"` unless otherwise specified.
+ *
+ * @type {import('../types.js').ConformanceRuleBase}
+ * */
 export default {
   id: 'ensure-valid-link-format',
   type: 'content',
@@ -148,7 +152,7 @@ export default {
         }
 
         // if we're running in the context of tutorials, check for specific old link formats
-        if (context.config?.isTutorials) {
+        if (context.config?.contentType === 'tutorials') {
           // Check if old search link (starts with "/search")
           if (
             pathname.startsWith('/search') &&

--- a/packages/content-conformance/src/rules/ensure-valid-link-format.js
+++ b/packages/content-conformance/src/rules/ensure-valid-link-format.js
@@ -75,7 +75,11 @@ export default {
         const isRelativePath = origin === TEST_URL_ORIGIN
 
         // Error if we detect folder-relative links
-        if (node.url.startsWith('.')) {
+        if (
+          node.url.startsWith('.') ||
+          // Handles folder-relative links such as "some/nested/folder". These can be problematic when trying to validate the correct destination. It's easier for us to enforce that all links are full paths.
+          (!node.url.startsWith('/') && isRelativePath)
+        ) {
           context.report(
             `Unexpected folder-relative link found: ${node.url}. Ensure this link is an absolute Developer path.`,
             file,

--- a/packages/content-conformance/src/test/utils.ts
+++ b/packages/content-conformance/src/test/utils.ts
@@ -21,7 +21,8 @@ function makeTestFileAndContext(
   rule: ConformanceRuleBase,
   fixture: VFileCompatible,
   contentFiles: VFileCompatible[] = [],
-  dataFiles: VFileCompatible[] = []
+  dataFiles: VFileCompatible[] = [],
+  config?: Record<string, any>
 ) {
   let file
   const context: ConformanceRuleContext = {
@@ -30,6 +31,7 @@ function makeTestFileAndContext(
     report: () => {
       void 0
     },
+    config,
   }
 
   switch (rule.type) {
@@ -71,14 +73,16 @@ export function testRule(
     messages: (string | RegExp)[]
     contentFiles?: VFileCompatible[]
     dataFiles?: VFileCompatible[]
-  }[]
+  }[],
+  config?: Record<string, any>
 ) {
   function test(testCase: typeof testCases[number]) {
     const [file, context] = makeTestFileAndContext(
       rule,
       testCase.fixture,
       testCase.contentFiles,
-      testCase.dataFiles
+      testCase.dataFiles,
+      config
     )
 
     switch (rule.type) {


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->
Ports over logic from the tutorials link format check to a conformance rule. The rule supports a configuration option called `isTutorials`, which we will set when configuring the rule to run in the tutorials repo.

Note: This rule is only concerned with the validity of the link structure, not necessarily that the links point to a valid location. We will rely on future rules / checks to ensure links are not broken.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203757634522303