### PR TITLE
fix: use full clone for canary release

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -21,7 +21,9 @@ jobs:
     if: contains( github.event.pull_request.labels.*.name, 'release:canary')
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v2


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

`changesets` will automatically deepen a shallow clone so that it can correctly generate changelogs and such. However, that functionality is fairly brittle, and will frequently cause infinite loops when attempting to deepen the checkout. Instead of that, this PR updates our checkout action to do a full clone (since that information is needed anyway), which prevents `changesets` from trying to do it itself (and failing).

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
