### PR TITLE
content-conformance: ensure-html-comments-on-own-line

### DIFF
--- a/packages/content-conformance/src/rules/__tests__/ensure-html-comments-on-own-line.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-html-comments-on-own-line.test.ts
@@ -16,7 +16,17 @@ describe('no-nested-html-comments', () => {
       {
         fixture: `* <!-- html-comment -->`,
         messages: [
-          'Detected an HTML comment that is likely nested. You may be using this in a bullet point or other markdown primitive, which is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+          'Detected an HTML comment that is likely nested. You may be using this in a bullet point or other markdown primitive, which is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
+        ],
+      },
+    ])
+    testRule(rule, [
+      {
+        fixture: `<Component>
+<!-- html-comment -->
+</Component>`,
+        messages: [
+          'Detected an HTML comment that is nested within a JSX Tag. This is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
         ],
       },
     ])
@@ -27,7 +37,7 @@ describe('no-nested-html-comments', () => {
       {
         fixture: ` <!-- html-comment -->`,
         messages: [
-          'Detected an HTML comment that is indented. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+          'Detected an HTML comment that is indented. This is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
         ],
       },
     ])
@@ -38,7 +48,7 @@ describe('no-nested-html-comments', () => {
       {
         fixture: `    <!-- html-comment -->`,
         messages: [
-          'Detected an HTML comment in a code block. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+          'Detected an HTML comment in a code block. This is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
         ],
       },
     ])

--- a/packages/content-conformance/src/rules/__tests__/ensure-html-comments-on-own-line.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/ensure-html-comments-on-own-line.test.ts
@@ -1,0 +1,46 @@
+import { testRule } from '../../test/utils.js'
+import rule from '../ensure-html-comments-on-own-line'
+
+describe('no-nested-html-comments', () => {
+  test('correctly formatted html comments', () => {
+    testRule(rule, [
+      {
+        fixture: `<!-- html-comment -->`,
+        messages: [],
+      },
+    ])
+  })
+
+  test('disallow nesting', () => {
+    testRule(rule, [
+      {
+        fixture: `* <!-- html-comment -->`,
+        messages: [
+          'Detected an HTML comment that is likely nested. You may be using this in a bullet point or other markdown primitive, which is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+        ],
+      },
+    ])
+  })
+
+  test('disallow indentation', () => {
+    testRule(rule, [
+      {
+        fixture: ` <!-- html-comment -->`,
+        messages: [
+          'Detected an HTML comment that is indented. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+        ],
+      },
+    ])
+  })
+
+  test('disallow html comments in codeblocks', () => {
+    testRule(rule, [
+      {
+        fixture: `    <!-- html-comment -->`,
+        messages: [
+          'Detected an HTML comment in a code block. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+        ],
+      },
+    ])
+  })
+})

--- a/packages/content-conformance/src/rules/ensure-html-comments-on-own-line.js
+++ b/packages/content-conformance/src/rules/ensure-html-comments-on-own-line.js
@@ -7,12 +7,12 @@ export default {
   executor: {
     async contentFile(file, context) {
       file.visit('jsx', (node) => {
-        // is HTML comment
+        // is HTML comment or JSX tag with HTML comment
         if (node.value.includes('<!--')) {
-          // // if child of another node
+          // if child of another node
           if (node.position.start.column != 1) {
             context.report(
-              'Detected an HTML comment that is likely nested. You may be using this in a bullet point or other markdown primitive, which is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+              'Detected an HTML comment that is likely nested. You may be using this in a bullet point or other markdown primitive, which is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
               file,
               node
             )
@@ -21,7 +21,16 @@ export default {
           // if leading whitespace
           if (node.value.match(/^\s/i)) {
             context.report(
-              'Detected an HTML comment that is indented. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+              'Detected an HTML comment that is indented. This is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
+              file,
+              node
+            )
+          }
+
+          // likely nested in JSX tag
+          if (!node.value.startsWith('<!')) {
+            context.report(
+              'Detected an HTML comment that is nested within a JSX Tag. This is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
               file,
               node
             )
@@ -33,7 +42,7 @@ export default {
       file.visit('code', (node) => {
         if (node.value.includes('<!--')) {
           context.report(
-            'Detected an HTML comment in a code block. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+            'Detected an HTML comment in a code block. This is not permitted. Please ensure HTML comments are on their own line, without any indentation or nesting.',
             file,
             node
           )

--- a/packages/content-conformance/src/rules/ensure-html-comments-on-own-line.js
+++ b/packages/content-conformance/src/rules/ensure-html-comments-on-own-line.js
@@ -1,0 +1,44 @@
+/* eslint-disable import/no-anonymous-default-export */
+/** @type {import('../types.js').ConformanceRuleBase} */
+export default {
+  type: 'content',
+  id: 'ensure-html-comments-on-own-line',
+  description: 'Ensures that HTML comments are on their own line.',
+  executor: {
+    async contentFile(file, context) {
+      file.visit('jsx', (node) => {
+        // is HTML comment
+        if (node.value.includes('<!--')) {
+          // // if child of another node
+          if (node.position.start.column != 1) {
+            context.report(
+              'Detected an HTML comment that is likely nested. You may be using this in a bullet point or other markdown primitive, which is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+              file,
+              node
+            )
+          }
+
+          // if leading whitespace
+          if (node.value.match(/^\s/i)) {
+            context.report(
+              'Detected an HTML comment that is indented. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+              file,
+              node
+            )
+          }
+        }
+      })
+
+      // check for accidental 4-space indentation (codeblock)
+      file.visit('code', (node) => {
+        if (node.value.includes('<!--')) {
+          context.report(
+            'Detected an HTML comment in a code block. This is not permitted. Please ensure HTML comments are on their own line, without any indentation.',
+            file,
+            node
+          )
+        }
+      })
+    },
+  },
+}


### PR DESCRIPTION

---

## Description

This adds a `ensure-html-comments-on-own-line` ContentConformance rule to ensure sure that HTML comments are authored on their own line, without any indentation.

```markdown
❌ No nesting in bullets / other primitives
* <!-- comment -->

❌ No indentation
*  <!-- comment -->

❌ No accidental usage in 4-space codeblocks
    <!-- comment -->
```


## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203847022231358