### PR TITLE
[Content Conformance] Add no-top-of-file-h1 rule

### DIFF
--- a/packages/content-conformance/src/rules/__tests__/no-top-of-file-h1.test.ts
+++ b/packages/content-conformance/src/rules/__tests__/no-top-of-file-h1.test.ts
@@ -1,0 +1,63 @@
+import fs from 'fs'
+import { testRule, getFixturePath } from '../../test/utils'
+import noTopOfFileH1 from '../no-top-of-file-h1'
+
+const fixturePath = getFixturePath('basic-with-content-files')
+
+describe('no-top-of-file-h1', () => {
+  test('Content with level 2 heading', () => {
+    testRule(noTopOfFileH1, [
+      {
+        fixture: {
+          path: `level-2-heading.mdx`,
+          value: `## Level 2 heading`,
+        },
+        messages: [],
+      },
+    ])
+  })
+
+  test('Content with no top level h1', () => {
+    testRule(noTopOfFileH1, [
+      {
+        fixture: {
+          path: `no-h1.mdx`,
+          value: `
+            This is some text
+
+            # Heading
+          `,
+        },
+        messages: [],
+      },
+    ])
+  })
+
+  test('Content with top level h1', () => {
+    testRule(noTopOfFileH1, [
+      {
+        fixture: {
+          path: `has-h1.mdx`,
+          value: `# Has level 1 heading`,
+        },
+        messages: [
+          `Expected file not to start with a level 1 heading. A level 1 heading is programmatically added to this page. Remove the level 1 heading at the top of the document.`,
+        ],
+      },
+    ])
+  })
+
+  test('Content with path to content file with H1', () => {
+    testRule(noTopOfFileH1, [
+      {
+        fixture: {
+          path: `${fixturePath}/content/index.mdx`,
+          value: String(fs.readFileSync(`${fixturePath}/content/index.mdx`)),
+        },
+        messages: [
+          `Expected file not to start with a level 1 heading. A level 1 heading is programmatically added to this page. Remove the level 1 heading at the top of the document.`,
+        ],
+      },
+    ])
+  })
+})

--- a/packages/content-conformance/src/rules/no-top-of-file-h1.js
+++ b/packages/content-conformance/src/rules/no-top-of-file-h1.js
@@ -1,0 +1,27 @@
+// eslint-disable-next-line import/no-anonymous-default-export
+/** @type {import('../types.js').ConformanceRuleBase} */
+export default {
+  type: 'content',
+  id: 'no-top-of-file-h1',
+  description: 'Each content file must not contain an H1 the top.',
+  executor: {
+    async contentFile(file, context) {
+      // Ignore partials as they do not represent the entire content file
+      if (file.isPartial) return false
+
+      file.visit(['root'], (node) => {
+        const firstNode = node.children[0]
+        const reportMessage = `Expected file not to start with a level 1 heading. A level 1 heading is programmatically added to this page. Remove the level 1 heading at the top of the document.`
+
+        if (firstNode.type === 'heading') {
+          context.report(reportMessage, file, firstNode)
+
+          return false
+        }
+
+        return true
+      })
+    },
+    dataFile() {},
+  },
+}


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1203331966445516/1204187603338179)

---

## Description

This PR adds a `no-top-of-file-h1` Content Conformance rule. This rule is meant to give some signal to an author for content that disallows top level h1s. 

For example: Tutorials content is injected with a heading programmatically, therefore omitting the need for content authors to add one themselves.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
