### PR TITLE
Replace Fathom custom domain with default URL

### DIFF
--- a/.changeset/rich-parents-rescue.md
+++ b/.changeset/rich-parents-rescue.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-analytics': minor
+---
+
+Update url used to load Fathom script - custom domains no longer work

--- a/packages/analytics/use-page-view-analytics/index.tsx
+++ b/packages/analytics/use-page-view-analytics/index.tsx
@@ -31,7 +31,7 @@ export default function usePageviewAnalytics({
       if (navigator.sendBeacon === undefined) return
 
       load(siteId, {
-        url: 'https://tarantula.hashicorp.com/script.js',
+        url: 'https://cdn.usefathom.com/script.js',
         includedDomains: includedDomains.split(' '),
       })
 


### PR DESCRIPTION
- update fathom script domain
- version package

🎟️ [Asana Task]()

---

## Description

Fathom has had upstream issues with their custom domain provider failing to renew SSL certificates, and have advised us that we should switch to their default CDN URL `cdn.usefathom.com/script.js`

This PR replaces our custom `tarantula.hashicorp.com` url with Fathom's default

<img width="1063" alt="image" src="https://github.com/hashicorp/web-platform-packages/assets/845983/16bba793-2fc8-44a6-8a49-d6908a0e23f0">


## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
