### PR TITLE
Bump all GitHub Actions and pin using TSCCR; avoid deprecated Node 12

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish Canary Packages
         id: changesets
-        uses: changesets/action@master # TSCCR: no entry for repository "changesets/action"
+        uses: changesets/action@master  # TSCCR: no entry for repository "changesets/action"
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release:canary
@@ -59,7 +59,7 @@ jobs:
           echo "::set-output name=packageList::$(echo ${{toJson(steps.changesets.outputs.publishedPackages)}} | jq 'reduce .[] as $item (""; . + "#### \($item.name)@\($item.version)\n```\nnpm install \($item.name)@canary\n```\n")')"
 
       - name: Comment
-        uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd # v2.5.0
+        uses: marocchino/sticky-pull-request-comment@f61b6cf21ef2fcc468f4345cdfcc9bda741d2343 # v2.6.2
         if: success() && steps.changesets.outputs.published == 'true'
         with:
           header: 'canary-release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@master # TSCCR: no entry for repository "changesets/action"
+        uses: changesets/action@master  # TSCCR: no entry for repository "changesets/action"
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

Commit is the result of: 'tsccr-helper -pin-all-workflows .'

https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

Note, this unsolicited PR is a courtesy and has not been tested before submission.  The PR should be evaluated and merged by its responsible team.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
