### PR TITLE
fix: update config value to partialsDirectories

### DIFF
--- a/.changeset/serious-pants-lie.md
+++ b/.changeset/serious-pants-lie.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-content-conformance': patch
+---
+
+Update partialsDirectory to partialsDirectories and add docs/partials

--- a/packages/content-conformance/README.md
+++ b/packages/content-conformance/README.md
@@ -69,7 +69,7 @@ Rules can be specified with differing severity to control the check's failure st
 export default {
   root: '.',
   contentFileGlobPattern: 'content/**/*.mdx',
-  partialsDirectory: 'content/partials',
+  partialsDirectories: ['content/partials'],
   rules: {
     'with-config': [
       'error',

--- a/packages/content-conformance/src/__tests__/__fixtures__/basic-with-content-files/docs/partials/some-partial.mdx
+++ b/packages/content-conformance/src/__tests__/__fixtures__/basic-with-content-files/docs/partials/some-partial.mdx
@@ -1,0 +1,1 @@
+I am a partial file

--- a/packages/content-conformance/src/__tests__/config.test.ts
+++ b/packages/content-conformance/src/__tests__/config.test.ts
@@ -18,7 +18,10 @@ describe('loadConfig', () => {
         "./rules/must-have-h1": "error",
       }
     `)
-    expect(config.partialsDirectory).toEqual('content/partials')
+    expect(config.partialsDirectories).toEqual([
+      'content/partials',
+      'docs/partials',
+    ])
   })
 
   test('it loads config presets', async () => {

--- a/packages/content-conformance/src/__tests__/content-file.test.ts
+++ b/packages/content-conformance/src/__tests__/content-file.test.ts
@@ -129,7 +129,7 @@ this is an invalid multi-line description.
     it('should set isPartial based on the path and partialsDirectory', () => {
       const file = new ContentFile(
         { value: 'I am a partial', path: 'content/partials/partial.mdx' },
-        { partialsDirectory: 'content/partials' }
+        { partialsDirectories: ['content/partials'] }
       )
 
       expect(file.isPartial).toBeTruthy()

--- a/packages/content-conformance/src/__tests__/content-file.test.ts
+++ b/packages/content-conformance/src/__tests__/content-file.test.ts
@@ -126,7 +126,7 @@ this is an invalid multi-line description.
       `)
     })
 
-    it('should set isPartial based on the path and partialsDirectory', () => {
+    it('should set isPartial based on the path and partialsDirectories', () => {
       const file = new ContentFile(
         { value: 'I am a partial', path: 'content/partials/partial.mdx' },
         { partialsDirectories: ['content/partials'] }

--- a/packages/content-conformance/src/__tests__/engine.test.ts
+++ b/packages/content-conformance/src/__tests__/engine.test.ts
@@ -144,4 +144,37 @@ describe('ContentConformanceEngine', () => {
       }
     `)
   })
+
+  test('detects partials in docs/partials', async () => {
+    const filePaths: Set<ContentFile> = new Set()
+    const opts = {
+      root: getFixturePath('basic-with-content-files'),
+      contentFileGlobPattern: '{content,docs}/**/*.mdx',
+      partialsDirectories: ['docs/partials'],
+      rules: [
+        {
+          level: 'warn' as const,
+          type: 'content' as const,
+          id: 'fake-rule-for-visiting-all-files',
+          description: 'This is a fake rule for testing purposes',
+          executor: {
+            async contentFile(file) {
+              // accumulate files for assertion
+              if (file.isPartial) filePaths.add(file.path)
+            },
+          },
+        },
+      ],
+    }
+
+    const engine = new ContentConformanceEngine(opts)
+
+    await engine.execute()
+
+    expect(filePaths).toMatchInlineSnapshot(`
+      Set {
+        "docs/partials/some-partial.mdx",
+      }
+    `)
+  })
 })

--- a/packages/content-conformance/src/config.ts
+++ b/packages/content-conformance/src/config.ts
@@ -7,7 +7,7 @@ import { loadModuleFromFilePath, getPackageFilePath } from './utils.js'
 const CONFIG_FILE_NAME = 'content-conformance.config.mjs'
 
 const CONFIG_DEFAULTS = {
-  partialsDirectory: 'content/partials',
+  partialsDirectories: ['content/partials', 'docs/partials'],
 }
 
 const RuleLevels = z.enum(['off', 'warn', 'error'])
@@ -22,7 +22,7 @@ const ContentConformanceConfig = z.object({
   root: z.string(),
   preset: z.string().optional(),
   contentFileGlobPattern: z.string(),
-  partialsDirectory: z.string().optional(),
+  partialsDirectories: z.array(z.string()).optional(),
   dataFileGlobPattern: z.string().optional(),
   presets: z.array(z.string()).optional(),
   rules: z.record(ContentConformanceConfigRule).optional(),
@@ -88,8 +88,8 @@ export async function loadConfig({
 }
 
 function applyConfigDefaults(config: ContentConformanceConfig) {
-  if (!config.partialsDirectory) {
-    config.partialsDirectory = CONFIG_DEFAULTS.partialsDirectory
+  if (!config.partialsDirectories) {
+    config.partialsDirectories = [...CONFIG_DEFAULTS.partialsDirectories]
   }
 }
 

--- a/packages/content-conformance/src/content-file.ts
+++ b/packages/content-conformance/src/content-file.ts
@@ -11,7 +11,7 @@ import type { Test } from 'unist-util-is'
 import type { Node } from 'unist'
 
 interface ContentFileOpts {
-  partialsDirectory?: string
+  partialsDirectories?: string[]
 }
 
 /**
@@ -35,9 +35,9 @@ export class ContentFile extends VFile {
     this.parseFrontmatter()
 
     // If a partialsDirectory is provided, check if the file is in the directory
-    if ((value as Options)?.path && opts?.partialsDirectory) {
-      this.isPartial = String((value as Options).path).startsWith(
-        opts.partialsDirectory
+    if ((value as Options)?.path && opts?.partialsDirectories) {
+      this.isPartial = opts.partialsDirectories.some((partialsDirectory) =>
+        String((value as Options).path).startsWith(partialsDirectory)
       )
     }
   }

--- a/packages/content-conformance/src/content-file.ts
+++ b/packages/content-conformance/src/content-file.ts
@@ -34,7 +34,7 @@ export class ContentFile extends VFile {
     super(value)
     this.parseFrontmatter()
 
-    // If a partialsDirectory is provided, check if the file is in the directory
+    // If a partialsDirectories is provided, check if the file is in the directory
     if ((value as Options)?.path && opts?.partialsDirectories) {
       this.isPartial = opts.partialsDirectories.some((partialsDirectory) =>
         String((value as Options).path).startsWith(partialsDirectory)

--- a/packages/content-conformance/src/engine.ts
+++ b/packages/content-conformance/src/engine.ts
@@ -73,7 +73,7 @@ export class ContentConformanceEngine {
           path: String(filepath),
           value: contents,
         },
-        { partialsDirectory: this.opts.partialsDirectory }
+        { partialsDirectories: this.opts.partialsDirectories }
       )
 
       this.contentFiles.push(file)


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->
Updating content conformance config value `partialsDirectory` to `partialsDirectories` and makes it an array. This allows us to check for multiple directories, specifically for terraform's content source repositories that use a `docs/` directory.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
