### PR TITLE
feat: add support for vercel visual editing

### DIFF
--- a/.changeset/witty-beans-chew.md
+++ b/.changeset/witty-beans-chew.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-cms': minor
+---
+
+Add support for Vercel & Dato visual editing

--- a/packages/cms/config.js
+++ b/packages/cms/config.js
@@ -6,9 +6,22 @@ let url = process.env.HASHI_DATO_ENVIRONMENT
 
 if (process.env.HASHI_ENV === 'preview') url += '/preview'
 
+const datoProjectSlug = process.env.HASHI_DATO_PROJECT || 'hashicorp'
+
+const visualEditingHeaders =
+  process.env.VERCEL_ENV === 'preview'
+    ? {
+        'X-Visual-Editing': 'vercel-v1',
+        'X-Base-Editing-Url': `https://${datoProjectSlug}.admin.datocms.com`,
+      }
+    : {}
+
 const token = process.env.HASHI_DATO_TOKEN || '2f7896a6b4f1948af64900319aed60'
 
 module.exports = {
   url,
-  headers: { Authorization: token },
+  headers: {
+    Authorization: token,
+    ...visualEditingHeaders,
+  },
 }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1204759139373945/f)

---

## Description

This adds necessary headers to our graphql requests to DatoCMS to enable the visual editing feature ([Vercel Docs](https://vercel.com/docs/workflow-collaboration/visual-editing) / [Dato Docs](https://www.datocms.com/docs/visual-editing/how-to-use-visual-editing))

This is similar to https://github.com/hashicorp/web/pull/455/files 

Note: before this merges (really before the version is bumped on consuming projects), each Vercel project that uses Dato will need to have a `HASHI_DATO_PROJECT` env variable added with the slug of the Dato URL. For us, possible values include:

* `hashicorp`
* `io-marketing-sites`
* `hashiconf`
* `hashidays`
* `internal-www`
* `how-hashicorp-works`

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
