### PR TITLE
fix: Cannot find module generate-slug imported from anchor-links/index.js

### DIFF
--- a/packages/remark-plugins/plugins/anchor-links/index.js
+++ b/packages/remark-plugins/plugins/anchor-links/index.js
@@ -1,4 +1,4 @@
-import { generateSlug, generateAriaLabel } from '../../util/generate-slug'
+import { generateSlug, generateAriaLabel } from '../../util/generate-slug.js'
 import { map } from 'unist-util-map'
 import { is } from 'unist-util-is'
 import { remark } from 'remark'


### PR DESCRIPTION
Fixes: #234

🎟️ [Asana Task]()

---

## Description

Fixes the following error when trying to import `anchorLinks`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/mark/xxx/node_modules/@hashicorp/platform-remark-plugins/util/generate-slug' imported from /home/mark/xxx/node_modules/@hashicorp/platform-remark-plugins/plugins/anchor-links/index.js
    at new NodeError (internal/errors.js:322:7)
    at finalizeResolution (internal/modules/esm/resolve.js:308:11)
    at moduleResolve (internal/modules/esm/resolve.js:731:10)
    at Loader.defaultResolve [as _resolve] (internal/modules/esm/resolve.js:842:11)
    at Loader.resolve (internal/modules/esm/loader.js:89:40)
    at Loader.getModuleJob (internal/modules/esm/loader.js:242:28)
    at ModuleWrap.<anonymous> (internal/modules/esm/module_job.js:76:40)
    at link (internal/modules/esm/module_job.js:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

The problem here is that the package has been migrated to ESM incompletely. Specifically, imports in an ESM project must include the file extension. This PR adds `.js` to the offending import.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
