### PR TITLE
fix: disable env file logging

### DIFF
--- a/.changeset/green-forks-compare.md
+++ b/.changeset/green-forks-compare.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-tools': minor
+---
+
+Disable .env file logging

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -49,7 +49,16 @@ async function main() {
     // Load env variables from .env using Next.js's utility
     const env = loadEnvConfig(
       process.cwd(),
-      process.env.NODE_ENV !== 'production'
+      process.env.NODE_ENV !== 'production',
+      {
+        info() {
+          // disable console.info calls for loaded env files
+          return
+        },
+        error(...args: any[]) {
+          console.error(...args)
+        },
+      }
     )
 
     const projectOptions = argv.project


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

This PR disables logging .env file loading when using `hc-tools`, which breaks scripts that expect the output to be JSON parseable.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
