### PR TITLE
Extend jsx-a11y to also look for Next.js Images

### DIFF
--- a/.changeset/shy-roses-wait.md
+++ b/.changeset/shy-roses-wait.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-cli': minor
+---
+
+Update the jsx/a11y alt text rule to check next.js images

--- a/packages/cli/config/.eslintrc.js
+++ b/packages/cli/config/.eslintrc.js
@@ -69,6 +69,14 @@ module.exports = {
       ],
 
       rules: {
+        // Extend jsx-a11y/alt-text to also look for Next.js Images
+        "jsx-a11y/alt-text": [2, {
+          "elements": ["img", "object", "area", "input[type=\"image\"]"],
+          "img": ["img", "Image", "NextImage"],
+          "object": ["Object"],
+          "area": ["Area"],
+          "input[type=\"image\"]": ["InputImage"]
+        }],
         // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
         'default-case': 'off',
         // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)


### PR DESCRIPTION
## Description

This PR extends the jsx-a11y/alt-text rule to also look for Next.js Images.

## PR Checklist 🚀

- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [X] Write a useful description (above) to give reviewers appropriate context.
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
