### PR TITLE
fix: add missing js extension

### DIFF
--- a/.changeset/slimy-moose-rest.md
+++ b/.changeset/slimy-moose-rest.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-remark-plugins': patch
+---
+
+Add .js extension to import statement

--- a/package-lock.json
+++ b/package-lock.json
@@ -38955,7 +38955,7 @@
     },
     "packages/cli": {
       "name": "@hashicorp/platform-cli",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@hashicorp/platform-cms": "0.4.0",
@@ -42348,7 +42348,7 @@
     },
     "packages/tools": {
       "name": "@hashicorp/platform-tools",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/packages/remark-plugins/plugins/anchor-links/index.js
+++ b/packages/remark-plugins/plugins/anchor-links/index.js
@@ -1,4 +1,4 @@
-import { generateSlug, generateAriaLabel } from '../../util/generate-slug'
+import { generateSlug, generateAriaLabel } from '../../util/generate-slug.js'
 import { map } from 'unist-util-map'
 import { is } from 'unist-util-is'
 import { remark } from 'remark'


### PR DESCRIPTION
🎟️ [Asana Task]()

---

## Description

This PR adds a missing `.js` extension to an import statement that was missing it. `remark-plugins` is an es module, so all imports from the filesystem need to have the extension.

## PR Checklist 🚀

- [ ] Conduct thorough self-review.
- [ ] Add or update tests as appropriate.
- [ ] Write a useful description (above) to give reviewers appropriate context.
- [ ] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
