### PR TITLE
fix(CMS): source environment variables

### DIFF
--- a/.changeset/modern-plums-sneeze.md
+++ b/.changeset/modern-plums-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@hashicorp/platform-cms": patch
+---
+
+fix(CMS): source environment variables

--- a/.changeset/modern-plums-sneeze.md
+++ b/.changeset/modern-plums-sneeze.md
@@ -1,5 +1,5 @@
 ---
-"@hashicorp/platform-cms": patch
+"@hashicorp/platform-cms": minor
 ---
 
 fix(CMS): source environment variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -39951,14 +39951,20 @@
       "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@next/env": "^14.2.3",
+        "dotenv": "^16.4.5",
         "rivet-graphql": "^0.6.0-canary-20230309231927"
       }
     },
-    "packages/cms/node_modules/@next/env": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+    "packages/cms/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "packages/code-highlighting": {
       "name": "@hashicorp/platform-code-highlighting",
@@ -45293,14 +45299,14 @@
     "@hashicorp/platform-cms": {
       "version": "file:packages/cms",
       "requires": {
-        "@next/env": "^14.2.3",
+        "dotenv": "^16.4.5",
         "rivet-graphql": "^0.6.0-canary-20230309231927"
       },
       "dependencies": {
-        "@next/env": {
-          "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-          "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+        "dotenv": {
+          "version": "16.4.5",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39951,14 +39951,17 @@
       "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "dotenv": "^16.4.5",
         "rivet-graphql": "^0.6.0-canary-20230309231927"
+      },
+      "devDependencies": {
+        "dotenv": "^16.4.5"
       }
     },
     "packages/cms/node_modules/dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -45306,7 +45309,8 @@
         "dotenv": {
           "version": "16.4.5",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
+          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39951,23 +39951,14 @@
       "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@next/env": "^14.2.3",
         "rivet-graphql": "^0.6.0-canary-20230309231927"
-      },
-      "devDependencies": {
-        "dotenv": "^16.4.5"
       }
     },
-    "packages/cms/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
+    "packages/cms/node_modules/@next/env": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
+      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
     },
     "packages/code-highlighting": {
       "name": "@hashicorp/platform-code-highlighting",
@@ -45302,15 +45293,14 @@
     "@hashicorp/platform-cms": {
       "version": "file:packages/cms",
       "requires": {
-        "dotenv": "^16.4.5",
+        "@next/env": "^14.2.3",
         "rivet-graphql": "^0.6.0-canary-20230309231927"
       },
       "dependencies": {
-        "dotenv": {
-          "version": "16.4.5",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-          "dev": true
+        "@next/env": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
+          "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39951,7 +39951,19 @@
       "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "rivet-graphql": "^0.6.0-canary-20230309231927"
+      }
+    },
+    "packages/cms/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/code-highlighting": {
@@ -41797,7 +41809,7 @@
     },
     "packages/remark-plugins": {
       "name": "@hashicorp/platform-remark-plugins",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "remark": "^14.0.1",
         "remark-html": "^15.0.0",
@@ -45287,7 +45299,15 @@
     "@hashicorp/platform-cms": {
       "version": "file:packages/cms",
       "requires": {
+        "dotenv": "^16.4.5",
         "rivet-graphql": "^0.6.0-canary-20230309231927"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "16.4.5",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
+        }
       }
     },
     "@hashicorp/platform-code-highlighting": {

--- a/packages/cms/config.js
+++ b/packages/cms/config.js
@@ -1,5 +1,7 @@
-const dotenv = require('dotenv')
-dotenv.config()
+const nextEnv = require('@next/env')
+const env = nextEnv.loadEnvConfig('../')
+console.log(env)
+console.log(process.cwd())
 
 // Return draft content from Dato app is in preview mode
 // Default to production endpoint if undefined to avoid unexpectedly exposing draft content

--- a/packages/cms/config.js
+++ b/packages/cms/config.js
@@ -1,5 +1,4 @@
-const nextEnv = require('@next/env')
-nextEnv.loadEnvConfig(process.cwd())
+require('dotenv').config()
 
 // Return draft content from Dato app is in preview mode
 // Default to production endpoint if undefined to avoid unexpectedly exposing draft content

--- a/packages/cms/config.js
+++ b/packages/cms/config.js
@@ -1,3 +1,6 @@
+const dotenv = require('dotenv')
+dotenv.config()
+
 // Return draft content from Dato app is in preview mode
 // Default to production endpoint if undefined to avoid unexpectedly exposing draft content
 let url = process.env.HASHI_DATO_ENVIRONMENT

--- a/packages/cms/config.js
+++ b/packages/cms/config.js
@@ -1,7 +1,5 @@
 const nextEnv = require('@next/env')
-const env = nextEnv.loadEnvConfig('../')
-console.log(env)
-console.log(process.cwd())
+nextEnv.loadEnvConfig(process.cwd())
 
 // Return draft content from Dato app is in preview mode
 // Default to production endpoint if undefined to avoid unexpectedly exposing draft content

--- a/packages/cms/config.js
+++ b/packages/cms/config.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('dotenv').config({ path: ['.env.local', '.env'] })
 
 // Return draft content from Dato app is in preview mode
 // Default to production endpoint if undefined to avoid unexpectedly exposing draft content

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -4,6 +4,7 @@
   "version": "0.4.0",
   "author": "HashiCorp",
   "dependencies": {
+    "dotenv": "^16.4.5",
     "rivet-graphql": "^0.6.0-canary-20230309231927"
   },
   "license": "MPL-2.0",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -4,6 +4,7 @@
   "version": "0.4.0",
   "author": "HashiCorp",
   "dependencies": {
+    "@next/env": "^14.2.3",
     "rivet-graphql": "^0.6.0-canary-20230309231927"
   },
   "license": "MPL-2.0",
@@ -15,8 +16,5 @@
     "type": "git",
     "url": "https://github.com/hashicorp/web-platform-packages.git",
     "directory": "packages/cms"
-  },
-  "devDependencies": {
-    "dotenv": "^16.4.5"
   }
 }

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -4,7 +4,7 @@
   "version": "0.4.0",
   "author": "HashiCorp",
   "dependencies": {
-    "@next/env": "^14.2.3",
+    "dotenv": "^16.4.5",
     "rivet-graphql": "^0.6.0-canary-20230309231927"
   },
   "license": "MPL-2.0",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -4,7 +4,6 @@
   "version": "0.4.0",
   "author": "HashiCorp",
   "dependencies": {
-    "dotenv": "^16.4.5",
     "rivet-graphql": "^0.6.0-canary-20230309231927"
   },
   "license": "MPL-2.0",
@@ -16,5 +15,8 @@
     "type": "git",
     "url": "https://github.com/hashicorp/web-platform-packages.git",
     "directory": "packages/cms"
+  },
+  "devDependencies": {
+    "dotenv": "^16.4.5"
   }
 }


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1202802428287999/1206364168206756/f)

---

## Description
Currently, when we [generate types from Dato](https://github.com/hashicorp/web/blob/main/apps/www/lib/dato/scripts/generate-types.js#L3), we do not source environment variables. As a result, `datoUrl` always evaluates to `undefined` and thus defaults to the primary Dato environment. This prevents developers from testing changes locally when using test Dato environments. This PR updates the `platform-cms` package to properly source environment variables.

## Validation Steps
- [ ] In the [`web` preview of this canary release](https://github.com/hashicorp/web/pull/1513/), validate that the [build logs](https://vercel.com/hashicorp/hashicorp-www-next/2sUAbnKJdUD5daZTTZc9hhmDBqH9) show the test environment URL for [the environment variable in `.env`](https://github.com/hashicorp/web/blob/2fdabd4885ca15664f50d353f5554b8538a9e540/apps/www/.env). It should look like this:
<img width="877" alt="Screenshot 2024-05-07 at 11 05 14 AM" src="https://github.com/hashicorp/web-platform-packages/assets/39201593/20b2d105-0a66-4d88-8718-4fef497fc4ac">

