### PR TITLE
fix: turn off cleanupIds for svgo loader

### DIFF
--- a/.changeset/plenty-fans-suffer.md
+++ b/.changeset/plenty-fans-suffer.md
@@ -1,0 +1,5 @@
+---
+'@hashicorp/platform-nextjs-plugin': patch
+---
+
+Turn off cleanupIds for svgo loader

--- a/package-lock.json
+++ b/package-lock.json
@@ -41797,7 +41797,7 @@
     },
     "packages/remark-plugins": {
       "name": "@hashicorp/platform-remark-plugins",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "remark": "^14.0.1",
         "remark-html": "^15.0.0",

--- a/packages/nextjs-plugin/src/plugins/with-inline-svg-loader.ts
+++ b/packages/nextjs-plugin/src/plugins/with-inline-svg-loader.ts
@@ -24,6 +24,7 @@ export function withInlineSvgLoader() {
                       overrides: {
                         removeViewBox: false,
                         collapseGroups: false,
+                        cleanupIds: false,
                       },
                     },
                   },

--- a/packages/nextjs-plugin/src/plugins/with-inline-svg-loader.ts
+++ b/packages/nextjs-plugin/src/plugins/with-inline-svg-loader.ts
@@ -24,7 +24,9 @@ export function withInlineSvgLoader() {
                       overrides: {
                         removeViewBox: false,
                         collapseGroups: false,
-                        cleanupIds: false,
+                        cleanupIds: {
+                          minify: false,
+                        },
                       },
                     },
                   },


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1206815131022336/1203910559645521/f)

---

## Description

<!-- Describe this pull request: what is it aiming to achieve? What should someone reviewing this PR know? -->

There is a problem on safari dev portal where a svg that is used as a background image is blurry. To fix this, I used the svg inline instead of as a background image. That worked in most places but on the hcp page, the svg was getting cut off. This was because the title svg being used was different from other products. This svg had a clip-path and the other product svgs do not. Since the new blurry svg and the title svg have a clip-path, there became a problem. Our svgo settings currently minify the ids on svgs to reduce size. However, if you have two svgs in the same spot, this can become a problem. The algorithm svgo uses is very simple and assigns the ids as a, b, c, ... Because of this, both svgs had a clip-path with an id of 'a' which caused the second svg to get cut off incorrectly. 

This PR fixes this problem. Certain plugins are installed as default for svgo, one of them being cleanupIds. This PR changes the settings for that plugin so the ids are no longer minified and we don't run into this problem anymore. There are more details about this setting at [the docs](https://svgo.dev/docs/plugins/cleanupIds/) and [this github issue](https://github.com/facebook/docusaurus/issues/8297#issuecomment-1742037037). Also, this is being used in [this dev-portal PR](https://github.com/hashicorp/dev-portal/pull/2507)

## Screenshots

Before
<img width="927" alt="Screenshot 2024-07-09 at 11 31 28 AM" src="https://github.com/hashicorp/web-platform-packages/assets/157434496/5a915ff8-7eca-4590-9631-049f6739e4a9">
After
<img width="923" alt="Screenshot 2024-07-09 at 11 30 03 AM" src="https://github.com/hashicorp/web-platform-packages/assets/157434496/b1f3451b-5f75-424e-9e6d-9d39e81383b5">


## Testing

1. Go to [dev portal preview](https://dev-portal-git-leah-fixblurry-svgs-safari-hashicorp.vercel.app/hcp)
2. Inspect the svgs on the 'Try cloud for free' component
3. Verify that the clip-paths are using the correct ids instead of 'a', 'b', 'c', etc.

## PR Checklist 🚀

- [x] Conduct thorough self-review.
- [x] Add or update tests as appropriate.
- [x] Write a useful description (above) to give reviewers appropriate context.
- [x] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
