### PR TITLE
Replace CHANGESETS_PAT with github and give perms

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,10 +1,11 @@
 name: Canary Release
 
+permissions:
+  pull-requests: write
+
 on:
   workflow_call:
     secrets:
-      CHANGESETS_PAT:
-        required: true
       NPM_TOKEN:
         required: true
   pull_request:
@@ -36,7 +37,7 @@ jobs:
       - name: Version
         run: npx changeset version --snapshot canary
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Canary Packages
         id: changesets
@@ -46,7 +47,7 @@ jobs:
           publish: npm run release:canary
           createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Compute new packages info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
+permissions:
+  pull-requests: write
+
 on:
   workflow_call:
     secrets:
-      CHANGESETS_PAT:
-        required: true
       NPM_TOKEN:
         required: true
   push:
@@ -37,5 +38,5 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
🎟️ Asana Task - None, fix for reported Github Action failures (e.g. [#1](https://github.com/hashicorp/web-platform-packages/actions/runs/9846586302/job/27186006321))

---

## Description

This PR replaces the CHANGESETS_PAT token with the always available GITHUB_TOKEN and sets it's permissions so that it can create PRs.

## Testing

None, because we have no local tests for this workflow. 😢 

## PR Checklist 🚀

- [X] Conduct thorough self-review.
- [X] Add or update tests as appropriate.
- [X] Write a useful description (above) to give reviewers appropriate context.
- [X] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
