### PR TITLE
Give write permission to the GHA token

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -1,9 +1,5 @@
 name: Canary Release
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -2,6 +2,7 @@ name: Canary Release
 
 permissions:
   pull-requests: write
+  contents: write
 
 on:
   workflow_call:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 permissions:
   pull-requests: write
+  contents: write
 
 on:
   workflow_call:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,5 @@
 name: Release
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
🎟️ Asana Task - None, fix for not enough permissions in previous fix. #269 

---

## Description

[We actually have what I believe are enough permissions on the default GHA token.](https://github.com/hashicorp/web-platform-packages/settings/actions#:~:text=Workflow%20permissions) And [setting specific permissions actually limits any non specified permissions:](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)

> If you specify the access for any of these scopes, all of those that are not specified are set to none.

I also double checked the action that needs this permission [changesets/action README](https://github.com/changesets/action) and it looks like it should work with the default token.

Soooo try 2.

## Testing

None, because we have no local tests for this workflow. 😢 

## PR Checklist 🚀

- [X] Conduct thorough self-review.
- [X] Add or update tests as appropriate.
- [X] Write a useful description (above) to give reviewers appropriate context.
- [X] Identify (in the description above) and document (add Asana tasks on [this board](https://app.asana.com/0/1100423001970639/list)) any technical debt that you're aware of, but are not addressing as part of this PR.
