### PR TITLE
fix: add permisions for github actions

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -17,6 +17,9 @@ jobs:
     name: Release Canary
     runs-on: ubuntu-latest
     if: contains( github.event.pull_request.labels.*.name, 'release:canary')
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     name: 'Run Tests 🧪'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
### Description

This PR adds permissions to all the github actions in this repo

### Testing

Make sure the checks on this PR pass

> [!NOTE]
> The test action has been failing for a while, make sure it runs and the error is not related to  `Resource not accessible by integration`